### PR TITLE
chore: add typecheck and check scripts across monorepo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Use lead/builder/verifier pattern with cost-conscious model allocation:
 
 - Always use `pnpm` (not npm)
 - Run `pnpm format` after making changes
+- Run `pnpm check` before committing (runs format:check + typecheck)
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -46,26 +46,26 @@ git clone <repository-url>
 cd herdbook
 ```
 
-2. Install dependencies:
+2. Set up environment variables (see [Environment Management](#environment-management) for details):
 
 ```bash
-pnpm install
+cp .env.example .env.local
+# Edit .env.local with your local database credentials
+pnpm env:local
 ```
 
-3. Set up environment variables (see [Environment Management](#environment-management) for details):
+3. Initialize the project:
 
-    ```bash
-    # Copy the example env files
-    cp .env.example .env.local
-    # Edit .env.local with your local database credentials
-    ```
+```bash
+pnpm init
+```
+
+This installs dependencies and generates the Prisma client.
 
 4. Set up the database:
 
 ```bash
-cd packages/api
-pnpm prisma:generate
-pnpm prisma:migrate
+pnpm --filter api prisma:migrate
 ```
 
 ## Development
@@ -130,12 +130,17 @@ herdbook/
 
 ### Root level:
 
+- `pnpm init` - Install dependencies and generate Prisma client
 - `pnpm dev` - Run both API and Web in development mode
 - `pnpm dev:api` - Run only the API server
 - `pnpm dev:web` - Run only the web app
 - `pnpm build` - Build all packages
 - `pnpm build:api` - Build only the API
 - `pnpm build:web` - Build only the web app
+- `pnpm check` - Run format check and typecheck across all packages
+- `pnpm typecheck` - Run TypeScript type checking across all packages
+- `pnpm format` - Auto-fix formatting with Prettier
+- `pnpm format:check` - Check formatting without modifying files
 - `pnpm test:e2e` - Run E2E tests
 
 ### API package (`packages/api`):

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
+        "init": "pnpm install && pnpm --filter api prisma:generate",
         "dev": "concurrently --names api,web --prefix \"[{name}]\" --prefix-colors \"magenta,cyan\" \"pnpm --filter api dev\" \"pnpm --filter web dev\"",
         "dev:api": "pnpm --filter api dev",
         "dev:web": "pnpm --filter web dev",
@@ -11,6 +12,8 @@
         "build:web": "pnpm --filter web build",
         "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
         "format:check": "prettier --check \"**/*.{ts,tsx,json,md}\"",
+        "typecheck": "pnpm -r run typecheck",
+        "check": "pnpm format:check && pnpm typecheck",
         "test": "pnpm --filter api test && pnpm --filter web test",
         "test:e2e": "pnpm --filter e2e test",
         "test:e2e:ui": "pnpm --filter e2e test:ui",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,6 +8,7 @@
         "dev": "tsx watch src/index.ts",
         "build": "pnpm run prisma:generate && tsc && tsc-alias",
         "start": "node dist/index.js",
+        "typecheck": "tsc --noEmit",
         "prisma:generate": "prisma generate",
         "prisma:migrate": "prisma migrate dev",
         "prisma:migrate:deploy": "prisma migrate deploy",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
         "typecheck": "tsc --noEmit",
         "test": "playwright test",
         "test:ui": "playwright test --ui"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,6 @@
         "dev": "vite --host",
         "build": "tsc && vite build",
         "start": "serve dist -l ${PORT:-3000} -s",
-        "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
         "typecheck": "tsc --noEmit",
         "preview": "vite preview",
         "test": "vitest run",


### PR DESCRIPTION
## Summary
- Add root `init`, `typecheck`, and `check` scripts for monorepo-wide quality checks
- Add missing `typecheck` script to api package
- Remove redundant per-package `format` scripts (root-level prettier covers everything)
- Update README installation flow to use `pnpm init`

## Usage
- `pnpm init` — set up a fresh clone (install deps + generate Prisma client)
- `pnpm check` — run format:check + typecheck across all packages (pre-commit)
- `pnpm typecheck` — run tsc --noEmit in all packages

## Test plan
- [x] `pnpm format:check` passes
- [x] `pnpm typecheck` passes for web and e2e (api requires env setup for Prisma generate)