### PR TITLE
chore(ci): install only webkit for E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,7 +27,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: pnpm --filter e2e exec playwright install --with-deps
+        run: pnpm --filter e2e exec playwright install --with-deps webkit
 
       - name: Build API
         run: pnpm --filter api build


### PR DESCRIPTION
## Summary
- Only install the webkit browser in CI since our Playwright config only uses Mobile Safari (iPhone 12)
- Skips downloading Chromium and Firefox, speeding up the browser install step

## Test plan
- [x] Verify E2E workflow passes with only webkit installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)