### PR TITLE
feat(e2e): reset database between spec files & install only webkit

### DIFF
--- a/packages/e2e/tests/auth.spec.ts
+++ b/packages/e2e/tests/auth.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { TEST_RIDER_EMAIL, TEST_RIDER_PASSWORD } from '@/seedConstants';
+import { resetDatabase } from './utils/resetDatabase';
+
+test.beforeAll(() => {
+    resetDatabase();
+});
 
 test.describe('Authentication', () => {
     test('can log in with valid credentials', async ({ page }) => {

--- a/packages/e2e/tests/horses.spec.ts
+++ b/packages/e2e/tests/horses.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
 import { TEST_RIDER_EMAIL, TEST_RIDER_PASSWORD } from '@/seedConstants';
+import { resetDatabase } from './utils/resetDatabase';
+
+test.beforeAll(() => {
+    resetDatabase();
+});
 
 test.describe('Horse Management', () => {
     test.beforeEach(async ({ page }) => {

--- a/packages/e2e/tests/navigation.spec.ts
+++ b/packages/e2e/tests/navigation.spec.ts
@@ -5,6 +5,11 @@ import {
     TEST_RIDER_NAME,
     TEST_HORSE_NAME,
 } from '@/seedConstants';
+import { resetDatabase } from './utils/resetDatabase';
+
+test.beforeAll(() => {
+    resetDatabase();
+});
 
 test.describe('Navigation', () => {
     test.beforeEach(async ({ page }) => {

--- a/packages/e2e/tests/sessions.spec.ts
+++ b/packages/e2e/tests/sessions.spec.ts
@@ -5,6 +5,11 @@ import {
     TEST_RIDER_EMAIL,
     TEST_RIDER_PASSWORD,
 } from '@/seedConstants';
+import { resetDatabase } from './utils/resetDatabase';
+
+test.beforeAll(() => {
+    resetDatabase();
+});
 
 /** Helper: open the field edit drawer, select an option, and wait for it to close */
 async function selectFieldOption(

--- a/packages/e2e/tests/utils/resetDatabase.ts
+++ b/packages/e2e/tests/utils/resetDatabase.ts
@@ -1,0 +1,20 @@
+import { execSync } from 'child_process';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT_DIR = resolve(__dirname, '../../../..');
+const DATABASE_URL = 'postgresql://postgres:test@127.0.0.1:5433/herdbook_test';
+
+export function resetDatabase(): void {
+    execSync(
+        `psql "${DATABASE_URL}" -c 'TRUNCATE TABLE "Session", "Horse", "Rider" CASCADE'`,
+        { stdio: 'pipe' }
+    );
+    execSync('pnpm --filter api prisma:seed:e2e', {
+        stdio: 'pipe',
+        cwd: ROOT_DIR,
+        env: { ...process.env, DATABASE_URL },
+    });
+}


### PR DESCRIPTION
## Summary
- Reset the database (truncate + re-seed) in `beforeAll` of each spec file so tests are isolated and don't leak state between files
- Install only webkit in CI instead of all browsers, since E2E tests only target Mobile Safari

## Test plan
- [ ] E2E tests pass in CI with database reset between spec files
- [ ] CI installs only webkit, reducing setup time

🤖 Generated with [Claude Code](https://claude.com/claude-code)