### PR TITLE
feat(api): add filter arguments to sessions query

### DIFF
--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -158,8 +158,33 @@ export const createResolvers = (app: FastifyInstance): Record<string, any> => {
             }),
             sessions: wrapResolver(
                 'read',
-                async (_, args: { limit?: number; offset?: number }) => {
+                async (
+                    _,
+                    args: {
+                        limit?: number;
+                        offset?: number;
+                        horseId?: string;
+                        riderId?: string;
+                        workType?: WorkType;
+                        dateFrom?: Date;
+                        dateTo?: Date;
+                    }
+                ) => {
+                    const where: Prisma.SessionWhereInput = {
+                        horseId: args.horseId,
+                        riderId: args.riderId,
+                        workType: args.workType,
+                    };
+
+                    if (args.dateFrom || args.dateTo) {
+                        where.date = {
+                            ...(args.dateFrom && { gte: args.dateFrom }),
+                            ...(args.dateTo && { lte: args.dateTo }),
+                        };
+                    }
+
                     return prisma.session.findMany({
+                        where,
                         take: args.limit,
                         skip: args.offset,
                         orderBy: { date: 'desc' },

--- a/packages/api/src/graphql/schema.graphql
+++ b/packages/api/src/graphql/schema.graphql
@@ -55,7 +55,15 @@ type AuthPayload {
 type Query {
     horses: [Horse!]!
     riders: [Rider!]!
-    sessions(limit: Int, offset: Int): [Session!]!
+    sessions(
+        limit: Int
+        offset: Int
+        horseId: ID
+        riderId: ID
+        workType: WorkType
+        dateFrom: DateTime
+        dateTo: DateTime
+    ): [Session!]!
     horse(id: ID!): Horse
     session(id: ID!): Session
     lastSessionForHorse(horseId: ID!): Session

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -3,17 +3,20 @@ import cors from '@fastify/cors';
 import multipart from '@fastify/multipart';
 import rateLimit from '@fastify/rate-limit';
 import { ApolloServer } from '@apollo/server';
+import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default';
 import fastifyApollo from '@as-integrations/fastify';
 import { buildSubgraphSchema } from '@apollo/subgraph';
 import { parse } from 'graphql';
 import { existsSync, readFileSync } from 'fs';
 import { resolve } from 'path';
 
-import { getJwtSecretOrThrow, getCorsOrigin } from '@/config';
+import jwt from 'jsonwebtoken';
+import { getJwtSecretOrThrow, getCorsOrigin, isDevelopment } from '@/config';
 import { createResolvers, type Context } from '@/graphql/resolvers';
 import { secureByDefaultTransformer } from '@/graphql/directives';
 import { buildContext } from '@/middleware/auth';
 import { registerVoiceRoutes } from '@/rest/voice';
+import { prisma } from '@/db';
 
 function readSchemaSDLOrThrow(): string {
     // In dev/test, this file lives next to this module in `src/graphql/`.
@@ -75,8 +78,37 @@ export async function createApiApp(httpsOptions?: {
         })
     );
 
+    const plugins = [];
+    if (isDevelopment()) {
+        const rider = await prisma.rider.findFirst({
+            select: { id: true, name: true },
+        });
+        if (rider) {
+            const devToken = jwt.sign(
+                { riderId: rider.id },
+                getJwtSecretOrThrow(),
+                { expiresIn: '7d' }
+            );
+            console.log(
+                `[sandbox] Dev token for ${rider.name} (expires in 7d)`
+            );
+            plugins.push(
+                ApolloServerPluginLandingPageLocalDefault({
+                    embed: {
+                        initialState: {
+                            sharedHeaders: {
+                                Authorization: `Bearer ${devToken}`,
+                            },
+                        },
+                    },
+                })
+            );
+        }
+    }
+
     const apollo = new ApolloServer<Context>({
         schema,
+        plugins,
     });
 
     await apollo.start();

--- a/packages/web/src/generated/graphql.ts
+++ b/packages/web/src/generated/graphql.ts
@@ -131,8 +131,13 @@ export type QuerySessionArgs = {
 };
 
 export type QuerySessionsArgs = {
+    dateFrom: InputMaybe<Scalars['DateTime']['input']>;
+    dateTo: InputMaybe<Scalars['DateTime']['input']>;
+    horseId: InputMaybe<Scalars['ID']['input']>;
     limit: InputMaybe<Scalars['Int']['input']>;
     offset: InputMaybe<Scalars['Int']['input']>;
+    riderId: InputMaybe<Scalars['ID']['input']>;
+    workType: InputMaybe<WorkType>;
 };
 
 export type Rider = {


### PR DESCRIPTION
## Summary
- Add optional filter args to `sessions` query: `horseId`, `riderId`, `workType`, `dateFrom`, `dateTo`
- All filters are composable with AND logic, existing `limit`/`offset` pagination unchanged
- Auto-inject dev JWT into Apollo Sandbox landing page so `/graphql` playground is pre-authenticated

## Test plan
- [ ] Query `sessions` with no filters — returns all sessions as before
- [ ] Filter by `horseId` — only sessions for that horse
- [ ] Filter by `workType` — only matching work type
- [ ] Filter by `dateFrom`/`dateTo` — correct date range
- [ ] Combine multiple filters — AND logic works
- [ ] Empty result set returns `[]` not an error
- [ ] Apollo Sandbox at `/graphql` has Authorization header pre-populated in dev

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)