### PR TITLE
Strengthen skills and add planning convention

### DIFF
--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -29,6 +29,7 @@ Display a summary: title, description, labels, and any relevant comments.
         - Explain why for each and alternatives you considered
         - Highlight any potential risks to performance or security with these changes
     - Key design decisions
+    - A **Skills** table mapping each step to the skill that will govern it (see CLAUDE.md Planning Convention)
     - Any open questions
 - **Wait for user approval before proceeding**
 

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -29,8 +29,30 @@ pnpm run test            # unit tests (API + web)
 | Cannot find `@prisma/client`     | `pnpm --filter api run prisma:generate` |
 | Stale types after schema change  | Run both generate commands above        |
 
+## Resolver Auth Check
+
+After checks pass, scan resolvers for missing auth:
+
+```bash
+# Find mutation resolvers missing context.rider check
+grep -n "Mutation:" packages/api/src/graphql/resolvers.ts -A 5
+```
+
+Every mutation resolver (except `login` and `signup`) must have:
+
+```typescript
+if (!context.rider) {
+    throw new GraphQLError('Not authenticated', {
+        extensions: { code: 'UNAUTHENTICATED' },
+    });
+}
+```
+
+Flag any mutation missing this pattern. Also flag queries that filter by `riderId` but accept it as a client argument instead of using `context.rider.id` — this is a data ownership gap.
+
 ## Workflow
 
 1. Run the appropriate command
 2. If errors: diagnose, fix, re-run `pnpm run check`
-3. Report result
+3. Run resolver auth check (for changes touching resolvers)
+4. Report result

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,22 @@ Use lead/builder/verifier pattern with cost-conscious model allocation:
 3. Build with Opus
 4. Verify with Sonnet (Opus for security-critical)
 
+### Planning Convention
+
+Every plan must include a **Skills** section that maps each implementation step to the skill that governs it. If no skill applies, write "none". This makes skill usage visible and reviewable.
+
+Example:
+
+```
+## Skills
+| Step | Skill | Why |
+|------|-------|-----|
+| Add birthDate to Horse model | `/schema` | Prisma → migration → GraphQL → resolver → codegen |
+| Build horse profile page | `/new-page` | New FullScreenLayout page with view/edit |
+| Write resolver tests | `/test-api` | Integration test for new query |
+| Pre-commit checks | `/preflight` | Format + typecheck |
+```
+
 ## Commands
 
 - Always use `pnpm` (not npm)


### PR DESCRIPTION
## Summary
- Add planning convention requiring a **Skills table** in every plan, making skill usage visible and reviewable
- Beef up 5 skills with concrete patterns from the actual codebase:
  - **preflight**: resolver auth check for missing `context.rider`
  - **new-page**: Apollo cache eviction patterns with real examples
  - **schema**: field/model removal workflow (reverse of creation)
  - **e2e**: create/edit/delete mutation test patterns with drawer helpers
  - **deploy-preview**: exact commands, rollback steps, troubleshooting table
- Update gh-issue to reference planning convention in explore & plan step

## Test plan
- [ ] Verify skills render correctly in Claude Code
- [ ] Test planning convention by running `/gh-issue` on a sample issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)