### PR TITLE
Filter UI on sessions page

### DIFF
--- a/packages/web/src/components/fields/SelectHorse.tsx
+++ b/packages/web/src/components/fields/SelectHorse.tsx
@@ -1,4 +1,3 @@
-import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
 
 import {
@@ -9,15 +8,7 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { GetHorsesQuery, GetHorsesQueryVariables } from '@/generated/graphql';
-
-const GET_HORSES_QUERY = gql`
-    query GetHorses {
-        horses {
-            id
-            name
-        }
-    }
-`;
+import { GET_HORSES_QUERY } from '@/lib/queries';
 
 export default function SelectHorse({
     value,

--- a/packages/web/src/components/fields/SelectRider.tsx
+++ b/packages/web/src/components/fields/SelectRider.tsx
@@ -1,4 +1,3 @@
-import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
 
 import {
@@ -8,17 +7,8 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-
 import { GetRidersQuery, GetRidersQueryVariables } from '@/generated/graphql';
-
-const GET_RIDERS_QUERY = gql`
-    query GetRiders {
-        riders {
-            id
-            name
-        }
-    }
-`;
+import { GET_RIDERS_QUERY } from '@/lib/queries';
 
 export default function SelectRider({
     value,

--- a/packages/web/src/components/fields/SelectWorkType.tsx
+++ b/packages/web/src/components/fields/SelectWorkType.tsx
@@ -1,4 +1,3 @@
-import { WorkType } from '@/generated/graphql';
 import {
     Select,
     SelectContent,
@@ -6,15 +5,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-
-const WORK_TYPE_OPTIONS: Array<{ value: WorkType; label: string }> = [
-    { value: WorkType.Flatwork, label: 'Flatwork' },
-    { value: WorkType.Groundwork, label: 'Groundwork' },
-    { value: WorkType.InHand, label: 'In-hand' },
-    { value: WorkType.Jumping, label: 'Jumping' },
-    { value: WorkType.Trail, label: 'Trail' },
-    { value: WorkType.Other, label: 'Other' },
-];
+import { WorkType, WORK_TYPE_OPTIONS } from '@/lib/constants';
 
 export default function SelectWorkType({
     value,

--- a/packages/web/src/components/ui/FilterChip.tsx
+++ b/packages/web/src/components/ui/FilterChip.tsx
@@ -1,0 +1,63 @@
+import { X, ChevronDown } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+interface FilterChipProps {
+    label: string;
+    activeLabel?: string | null;
+    isActive: boolean;
+    onPress: () => void;
+    onClear: () => void;
+}
+
+export default function FilterChip({
+    label,
+    activeLabel,
+    isActive,
+    onPress,
+    onClear,
+}: FilterChipProps): React.ReactNode {
+    return (
+        <button
+            type="button"
+            onClick={onPress}
+            className={cn(
+                'inline-flex items-center gap-1.5 shrink-0',
+                'rounded-full px-3.5 h-9 text-sm font-medium',
+                'transition-all duration-200 ease-out',
+                'active:scale-[0.96]',
+                isActive
+                    ? 'bg-primary text-primary-foreground shadow-sm'
+                    : 'bg-secondary/70 text-foreground border border-border hover:bg-secondary'
+            )}
+        >
+            <span className="truncate max-w-[120px]">
+                {isActive && activeLabel ? activeLabel : label}
+            </span>
+
+            {isActive ? (
+                <span
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Clear ${label} filter`}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        onClear();
+                    }}
+                    onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            e.stopPropagation();
+                            e.preventDefault();
+                            onClear();
+                        }
+                    }}
+                    className="ml-0.5 -mr-1 rounded-full p-0.5 hover:bg-primary-foreground/20 transition-colors"
+                >
+                    <X className="w-3.5 h-3.5" />
+                </span>
+            ) : (
+                <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />
+            )}
+        </button>
+    );
+}

--- a/packages/web/src/components/ui/PickerSheet.tsx
+++ b/packages/web/src/components/ui/PickerSheet.tsx
@@ -1,0 +1,63 @@
+import { Check } from 'lucide-react';
+
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+
+export interface PickerSheetItem {
+    key: string;
+    label: string;
+    icon?: React.ReactNode;
+}
+
+interface PickerSheetProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    title: string;
+    items: PickerSheetItem[];
+    selectedKey: string | null;
+    onSelect: (key: string) => void;
+    children?: React.ReactNode;
+}
+
+export default function PickerSheet({
+    open,
+    onOpenChange,
+    title,
+    items,
+    selectedKey,
+    onSelect,
+    children,
+}: PickerSheetProps): React.ReactNode {
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent side="bottom" className="max-h-[80vh] overflow-auto">
+                <SheetHeader>
+                    <SheetTitle>{title}</SheetTitle>
+                </SheetHeader>
+                <div className="space-y-1 mt-4">
+                    {items.map((item) => (
+                        <button
+                            key={item.key}
+                            type="button"
+                            onClick={() => onSelect(item.key)}
+                            className="w-full flex items-center justify-between py-3 px-3 rounded-lg hover:bg-muted active:bg-muted transition-colors"
+                        >
+                            <div className="flex items-center gap-2.5">
+                                {item.icon}
+                                <span className="text-base">{item.label}</span>
+                            </div>
+                            {selectedKey === item.key && (
+                                <Check className="h-5 w-5 text-primary" />
+                            )}
+                        </button>
+                    ))}
+                </div>
+                {children}
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/packages/web/src/hooks/useSessionFilters.ts
+++ b/packages/web/src/hooks/useSessionFilters.ts
@@ -1,0 +1,256 @@
+import { useMemo, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import { WorkType, WORK_TYPE_LABELS } from '@/lib/constants';
+
+// --- Date range types ---
+
+export type DatePreset = 'thisWeek' | 'thisMonth' | 'last30Days';
+
+export type DateRangeValue =
+    | { kind: 'preset'; preset: DatePreset }
+    | { kind: 'custom'; from: string; to: string };
+
+const DATE_PRESETS: DatePreset[] = ['thisWeek', 'thisMonth', 'last30Days'];
+
+const DATE_PRESET_LABELS: Record<DatePreset, string> = {
+    thisWeek: 'This week',
+    thisMonth: 'This month',
+    last30Days: 'Last 30 days',
+};
+
+function isDatePreset(value: string): value is DatePreset {
+    return (DATE_PRESETS as string[]).includes(value);
+}
+
+function resolveDateRange(value: DateRangeValue): {
+    dateFrom: string;
+    dateTo: string;
+} {
+    if (value.kind === 'custom') {
+        return {
+            dateFrom: new Date(value.from).toISOString(),
+            dateTo: new Date(`${value.to}T23:59:59`).toISOString(),
+        };
+    }
+
+    const now = new Date();
+    const endOfToday = new Date(
+        now.getFullYear(),
+        now.getMonth(),
+        now.getDate(),
+        23,
+        59,
+        59
+    );
+
+    let start: Date;
+
+    switch (value.preset) {
+        case 'thisWeek': {
+            const day = now.getDay();
+            const diff = day === 0 ? 6 : day - 1; // Monday = start of week
+            start = new Date(
+                now.getFullYear(),
+                now.getMonth(),
+                now.getDate() - diff
+            );
+            break;
+        }
+        case 'thisMonth':
+            start = new Date(now.getFullYear(), now.getMonth(), 1);
+            break;
+        case 'last30Days':
+            start = new Date(
+                now.getFullYear(),
+                now.getMonth(),
+                now.getDate() - 30
+            );
+            break;
+    }
+
+    return {
+        dateFrom: start.toISOString(),
+        dateTo: endOfToday.toISOString(),
+    };
+}
+
+// --- Horse filter type ---
+
+export interface HorseFilter {
+    id: string;
+    name: string;
+}
+
+// --- Hook return type ---
+
+interface SessionFiltersResult {
+    horse: HorseFilter | null;
+    workType: WorkType | null;
+    dateRange: DateRangeValue | null;
+
+    queryVariables: {
+        horseId?: string;
+        workType?: WorkType;
+        dateFrom?: string;
+        dateTo?: string;
+    };
+
+    horseLabel: string | null;
+    workTypeLabel: string | null;
+    dateRangeLabel: string | null;
+
+    setHorse: (horse: HorseFilter | null) => void;
+    setWorkType: (type: WorkType | null) => void;
+    setDateRange: (range: DateRangeValue | null) => void;
+
+    hasActiveFilters: boolean;
+}
+
+// --- Read filters from URL search params ---
+
+function parseHorse(params: URLSearchParams): HorseFilter | null {
+    const id = params.get('horseId');
+    const name = params.get('horseName');
+    return id && name ? { id, name } : null;
+}
+
+function parseWorkType(params: URLSearchParams): WorkType | null {
+    const raw = params.get('workType');
+    if (raw && Object.values(WorkType).includes(raw as WorkType)) {
+        return raw as WorkType;
+    }
+    return null;
+}
+
+function parseDateRange(params: URLSearchParams): DateRangeValue | null {
+    const preset = params.get('datePreset');
+    if (preset && isDatePreset(preset)) {
+        return { kind: 'preset', preset };
+    }
+    const from = params.get('dateFrom');
+    const to = params.get('dateTo');
+    if (from && to) {
+        return { kind: 'custom', from, to };
+    }
+    return null;
+}
+
+export default function useSessionFilters(): SessionFiltersResult {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    // Derive filter state from URL
+    const horse = useMemo(() => parseHorse(searchParams), [searchParams]);
+    const workType = useMemo(() => parseWorkType(searchParams), [searchParams]);
+    const dateRange = useMemo(
+        () => parseDateRange(searchParams),
+        [searchParams]
+    );
+
+    // Helper: update params with replace (don't push history entries for filter changes)
+    const updateParams = useCallback(
+        (updater: (prev: URLSearchParams) => URLSearchParams) => {
+            setSearchParams(
+                (prev) => {
+                    return updater(new URLSearchParams(prev));
+                },
+                { replace: true }
+            );
+        },
+        [setSearchParams]
+    );
+
+    const setHorse = useCallback(
+        (h: HorseFilter | null) => {
+            updateParams((p) => {
+                if (h) {
+                    p.set('horseId', h.id);
+                    p.set('horseName', h.name);
+                } else {
+                    p.delete('horseId');
+                    p.delete('horseName');
+                }
+                return p;
+            });
+        },
+        [updateParams]
+    );
+
+    const setWorkType = useCallback(
+        (wt: WorkType | null) => {
+            updateParams((p) => {
+                if (wt) {
+                    p.set('workType', wt);
+                } else {
+                    p.delete('workType');
+                }
+                return p;
+            });
+        },
+        [updateParams]
+    );
+
+    const setDateRange = useCallback(
+        (dr: DateRangeValue | null) => {
+            updateParams((p) => {
+                p.delete('datePreset');
+                p.delete('dateFrom');
+                p.delete('dateTo');
+                if (dr) {
+                    if (dr.kind === 'preset') {
+                        p.set('datePreset', dr.preset);
+                    } else {
+                        p.set('dateFrom', dr.from);
+                        p.set('dateTo', dr.to);
+                    }
+                }
+                return p;
+            });
+        },
+        [updateParams]
+    );
+
+    const queryVariables = useMemo(() => {
+        const vars: SessionFiltersResult['queryVariables'] = {};
+        if (horse) vars.horseId = horse.id;
+        if (workType) vars.workType = workType;
+        if (dateRange) {
+            const resolved = resolveDateRange(dateRange);
+            vars.dateFrom = resolved.dateFrom;
+            vars.dateTo = resolved.dateTo;
+        }
+        return vars;
+    }, [horse, workType, dateRange]);
+
+    const horseLabel = horse?.name ?? null;
+    const workTypeLabel = workType ? WORK_TYPE_LABELS[workType] : null;
+
+    const dateRangeLabel = useMemo(() => {
+        if (!dateRange) return null;
+        if (dateRange.kind === 'preset') {
+            return DATE_PRESET_LABELS[dateRange.preset];
+        }
+        const from = new Date(dateRange.from);
+        const to = new Date(dateRange.to);
+        const fmt = (d: Date): string =>
+            d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+        return `${fmt(from)} – ${fmt(to)}`;
+    }, [dateRange]);
+
+    const hasActiveFilters =
+        horse !== null || workType !== null || dateRange !== null;
+
+    return {
+        horse,
+        workType,
+        dateRange,
+        queryVariables,
+        horseLabel,
+        workTypeLabel,
+        dateRangeLabel,
+        setHorse,
+        setWorkType,
+        setDateRange,
+        hasActiveFilters,
+    };
+}

--- a/packages/web/src/lib/constants.ts
+++ b/packages/web/src/lib/constants.ts
@@ -6,10 +6,22 @@ export const WORK_TYPE_LABELS: Record<WorkType, string> = {
     [WorkType.Flatwork]: 'Flatwork',
     [WorkType.Jumping]: 'Jumping',
     [WorkType.Groundwork]: 'Groundwork',
-    [WorkType.InHand]: 'In Hand',
+    [WorkType.InHand]: 'In-hand',
     [WorkType.Trail]: 'Trail',
     [WorkType.Other]: 'Other',
 };
+
+export const WORK_TYPE_OPTIONS: Array<{ value: WorkType; label: string }> = [
+    { value: WorkType.Flatwork, label: WORK_TYPE_LABELS[WorkType.Flatwork] },
+    {
+        value: WorkType.Groundwork,
+        label: WORK_TYPE_LABELS[WorkType.Groundwork],
+    },
+    { value: WorkType.InHand, label: WORK_TYPE_LABELS[WorkType.InHand] },
+    { value: WorkType.Jumping, label: WORK_TYPE_LABELS[WorkType.Jumping] },
+    { value: WorkType.Trail, label: WORK_TYPE_LABELS[WorkType.Trail] },
+    { value: WorkType.Other, label: WORK_TYPE_LABELS[WorkType.Other] },
+];
 
 export const getWorkTypeLabel = (workType: string): string => {
     return WORK_TYPE_LABELS[workType as WorkType] || workType;

--- a/packages/web/src/lib/queries.ts
+++ b/packages/web/src/lib/queries.ts
@@ -1,0 +1,19 @@
+import { gql } from '@apollo/client';
+
+export const GET_HORSES_QUERY = gql`
+    query GetHorses {
+        horses {
+            id
+            name
+        }
+    }
+`;
+
+export const GET_RIDERS_QUERY = gql`
+    query GetRiders {
+        riders {
+            id
+            name
+        }
+    }
+`;

--- a/packages/web/src/pages/EditSession.tsx
+++ b/packages/web/src/pages/EditSession.tsx
@@ -8,6 +8,7 @@ import type { SessionValues } from '@/components/session/SessionEditor';
 import { useAppNavigate } from '@/hooks/useAppNavigate';
 import { useAuth } from '@/context/AuthContext';
 import { formatAsDateTimeLocalValue } from '@/lib/dateUtils';
+import { GET_HORSES_QUERY, GET_RIDERS_QUERY } from '@/lib/queries';
 import {
     WorkType,
     CreateSessionMutation,
@@ -47,24 +48,6 @@ const CREATE_SESSION_MUTATION = gql`
             notes: $notes
         ) {
             id
-        }
-    }
-`;
-
-const GET_HORSES_QUERY = gql`
-    query GetHorses {
-        horses {
-            id
-            name
-        }
-    }
-`;
-
-const GET_RIDERS_QUERY = gql`
-    query GetRiders {
-        riders {
-            id
-            name
         }
     }
 `;

--- a/packages/web/src/pages/SessionDetail.tsx
+++ b/packages/web/src/pages/SessionDetail.tsx
@@ -35,6 +35,7 @@ import {
     formatAsDateTimeLocalValue,
 } from '@/lib/dateUtils';
 import { getWorkTypeLabel } from '@/lib/constants';
+import { GET_HORSES_QUERY, GET_RIDERS_QUERY } from '@/lib/queries';
 import {
     WorkType,
     GetSessionForEditQuery,
@@ -96,24 +97,6 @@ const UPDATE_SESSION_MUTATION = gql`
 const DELETE_SESSION_MUTATION = gql`
     mutation DeleteSession($id: ID!) {
         deleteSession(id: $id)
-    }
-`;
-
-const GET_HORSES_QUERY = gql`
-    query GetHorses {
-        horses {
-            id
-            name
-        }
-    }
-`;
-
-const GET_RIDERS_QUERY = gql`
-    query GetRiders {
-        riders {
-            id
-            name
-        }
     }
 `;
 

--- a/packages/web/src/pages/Sessions.tsx
+++ b/packages/web/src/pages/Sessions.tsx
@@ -1,17 +1,43 @@
+import { useState } from 'react';
 import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
+import { Calendar, SlidersHorizontal } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
+import FilterChip from '@/components/ui/FilterChip';
+import PickerSheet from '@/components/ui/PickerSheet';
 import ActivityCard from '@/components/ActivityCard';
 import { useAppNavigate } from '@/hooks/useAppNavigate';
+import useSessionFilters, { type DatePreset } from '@/hooks/useSessionFilters';
+import { WorkType, WORK_TYPE_LABELS } from '@/lib/constants';
+import { GET_HORSES_QUERY } from '@/lib/queries';
+import type {
+    GetHorsesQuery,
+    GetHorsesQueryVariables,
+} from '@/generated/graphql';
 
 const PAGE_SIZE = 20;
 
 const SESSIONS_QUERY = gql`
-    query GetSessions($limit: Int, $offset: Int) {
-        sessions(limit: $limit, offset: $offset) {
+    query GetSessions(
+        $limit: Int
+        $offset: Int
+        $horseId: ID
+        $workType: WorkType
+        $dateFrom: DateTime
+        $dateTo: DateTime
+    ) {
+        sessions(
+            limit: $limit
+            offset: $offset
+            horseId: $horseId
+            workType: $workType
+            dateFrom: $dateFrom
+            dateTo: $dateTo
+        ) {
             id
             date
             durationMinutes
@@ -41,6 +67,35 @@ interface SessionsData {
     sessions: SessionItem[];
 }
 
+type FilterSheet = 'horse' | 'workType' | 'dateRange' | null;
+
+const WORK_TYPE_ITEMS = Object.values(WorkType).map((wt) => ({
+    key: wt,
+    label: WORK_TYPE_LABELS[wt],
+}));
+
+const DATE_PRESET_ITEMS: Array<{
+    key: DatePreset;
+    label: string;
+    icon: React.ReactNode;
+}> = [
+    {
+        key: 'thisWeek',
+        label: 'This week',
+        icon: <Calendar className="w-4 h-4 text-muted-foreground" />,
+    },
+    {
+        key: 'thisMonth',
+        label: 'This month',
+        icon: <Calendar className="w-4 h-4 text-muted-foreground" />,
+    },
+    {
+        key: 'last30Days',
+        label: 'Last 30 days',
+        icon: <Calendar className="w-4 h-4 text-muted-foreground" />,
+    },
+];
+
 function SessionSkeleton(): React.ReactNode {
     return (
         <Card>
@@ -66,10 +121,26 @@ function SessionSkeleton(): React.ReactNode {
 
 export default function Sessions(): React.ReactNode {
     const { push } = useAppNavigate();
+    const filters = useSessionFilters();
+    const [openSheet, setOpenSheet] = useState<FilterSheet>(null);
+    const [customFrom, setCustomFrom] = useState('');
+    const [customTo, setCustomTo] = useState('');
+
+    const { data: horsesData } = useQuery<
+        GetHorsesQuery,
+        GetHorsesQueryVariables
+    >(GET_HORSES_QUERY);
+
+    const horses = horsesData?.horses ?? [];
+
     const { data, loading, fetchMore } = useQuery<SessionsData>(
         SESSIONS_QUERY,
         {
-            variables: { limit: PAGE_SIZE, offset: 0 },
+            variables: {
+                limit: PAGE_SIZE,
+                offset: 0,
+                ...filters.queryVariables,
+            },
         }
     );
 
@@ -78,7 +149,11 @@ export default function Sessions(): React.ReactNode {
 
     const handleLoadMore = (): void => {
         fetchMore({
-            variables: { limit: PAGE_SIZE, offset: sessions.length },
+            variables: {
+                limit: PAGE_SIZE,
+                offset: sessions.length,
+                ...filters.queryVariables,
+            },
             updateQuery(prev, { fetchMoreResult }) {
                 if (!fetchMoreResult) return prev;
                 return {
@@ -88,9 +163,51 @@ export default function Sessions(): React.ReactNode {
         });
     };
 
+    const handleCustomDateApply = (): void => {
+        if (customFrom && customTo) {
+            filters.setDateRange({
+                kind: 'custom',
+                from: customFrom,
+                to: customTo,
+            });
+            setOpenSheet(null);
+        }
+    };
+
     return (
         <div className="p-4 space-y-4">
             <h1 className="text-lg font-semibold">Sessions</h1>
+
+            {/* Filter chip bar */}
+            <div
+                className="flex gap-2 overflow-x-auto -mx-4 px-4 pb-1"
+                style={{
+                    scrollbarWidth: 'none',
+                    WebkitOverflowScrolling: 'touch',
+                }}
+            >
+                <FilterChip
+                    label="Horse"
+                    activeLabel={filters.horseLabel}
+                    isActive={filters.horse !== null}
+                    onPress={() => setOpenSheet('horse')}
+                    onClear={() => filters.setHorse(null)}
+                />
+                <FilterChip
+                    label="Work type"
+                    activeLabel={filters.workTypeLabel}
+                    isActive={filters.workType !== null}
+                    onPress={() => setOpenSheet('workType')}
+                    onClear={() => filters.setWorkType(null)}
+                />
+                <FilterChip
+                    label="Date"
+                    activeLabel={filters.dateRangeLabel}
+                    isActive={filters.dateRange !== null}
+                    onPress={() => setOpenSheet('dateRange')}
+                    onClear={() => filters.setDateRange(null)}
+                />
+            </div>
 
             {loading ? (
                 <div className="space-y-3">
@@ -99,8 +216,15 @@ export default function Sessions(): React.ReactNode {
                     <SessionSkeleton />
                 </div>
             ) : sessions.length === 0 ? (
-                <div className="text-center text-muted-foreground py-12">
-                    <p>No sessions yet.</p>
+                <div className="text-center text-muted-foreground py-12 space-y-3">
+                    {filters.hasActiveFilters ? (
+                        <>
+                            <SlidersHorizontal className="w-8 h-8 mx-auto opacity-40" />
+                            <p>No sessions match your filters.</p>
+                        </>
+                    ) : (
+                        <p>No sessions yet.</p>
+                    )}
                 </div>
             ) : (
                 <div className="space-y-3">
@@ -123,6 +247,99 @@ export default function Sessions(): React.ReactNode {
                     )}
                 </div>
             )}
+
+            {/* Horse filter */}
+            <PickerSheet
+                open={openSheet === 'horse'}
+                onOpenChange={(open) => !open && setOpenSheet(null)}
+                title="Filter by Horse"
+                items={horses.map((h) => ({ key: h.id, label: h.name }))}
+                selectedKey={filters.horse?.id ?? null}
+                onSelect={(key) => {
+                    const horse = horses.find((h) => h.id === key);
+                    if (horse)
+                        filters.setHorse({ id: horse.id, name: horse.name });
+                    setOpenSheet(null);
+                }}
+            />
+
+            {/* Work type filter */}
+            <PickerSheet
+                open={openSheet === 'workType'}
+                onOpenChange={(open) => !open && setOpenSheet(null)}
+                title="Filter by Work Type"
+                items={WORK_TYPE_ITEMS}
+                selectedKey={filters.workType}
+                onSelect={(key) => {
+                    filters.setWorkType(key as WorkType);
+                    setOpenSheet(null);
+                }}
+            />
+
+            {/* Date range filter */}
+            <PickerSheet
+                open={openSheet === 'dateRange'}
+                onOpenChange={(open) => !open && setOpenSheet(null)}
+                title="Filter by Date"
+                items={DATE_PRESET_ITEMS}
+                selectedKey={
+                    filters.dateRange?.kind === 'preset'
+                        ? filters.dateRange.preset
+                        : null
+                }
+                onSelect={(key) => {
+                    filters.setDateRange({
+                        kind: 'preset',
+                        preset: key as DatePreset,
+                    });
+                    setOpenSheet(null);
+                }}
+            >
+                {/* Custom date range */}
+                <div className="my-4 border-t border-border" />
+                <div className="space-y-3">
+                    <p className="text-sm font-medium text-muted-foreground px-1">
+                        Custom range
+                    </p>
+                    <div className="grid grid-cols-2 gap-3">
+                        <div className="space-y-1.5">
+                            <label
+                                htmlFor="date-from"
+                                className="text-xs text-muted-foreground px-1"
+                            >
+                                From
+                            </label>
+                            <Input
+                                id="date-from"
+                                type="date"
+                                value={customFrom}
+                                onChange={(e) => setCustomFrom(e.target.value)}
+                            />
+                        </div>
+                        <div className="space-y-1.5">
+                            <label
+                                htmlFor="date-to"
+                                className="text-xs text-muted-foreground px-1"
+                            >
+                                To
+                            </label>
+                            <Input
+                                id="date-to"
+                                type="date"
+                                value={customTo}
+                                onChange={(e) => setCustomTo(e.target.value)}
+                            />
+                        </div>
+                    </div>
+                    <Button
+                        onClick={handleCustomDateApply}
+                        className="w-full"
+                        disabled={!customFrom || !customTo}
+                    >
+                        Apply range
+                    </Button>
+                </div>
+            </PickerSheet>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Adds horizontally scrollable filter chip bar (Horse, Work Type, Date Range) to the sessions list page
- Filters persist in URL search params so they survive navigating to session detail and back, but reset when switching tabs
- Introduces reusable `PickerSheet` component used by both filter sheets and `FieldEditSheet` (drawer editing)
- Consolidates duplicated GraphQL queries (`GET_HORSES_QUERY`, `GET_RIDERS_QUERY`) into shared `lib/queries.ts`
- Consolidates `WORK_TYPE_OPTIONS` into `lib/constants.ts` as single source of truth

## Test plan
- [x] All 20 E2E tests pass (including new filter test)
- [x] Preflight passes (formatting + typecheck)
- [ ] Manually verify filter chips on `/sessions` — tap to open sheet, select option, chip turns active
- [ ] Verify clearing filter via × button restores full list
- [ ] Verify filter persists when tapping a session card and going back
- [ ] Verify filters reset when navigating away via bottom tab bar

Closes #21