### PR TITLE
Link sessions page from dashboard and horse profile

### DIFF
--- a/packages/web/src/generated/graphql.ts
+++ b/packages/web/src/generated/graphql.ts
@@ -177,20 +177,6 @@ export enum WorkType {
     Trail = 'TRAIL',
 }
 
-export type GetHorsesQueryVariables = Exact<{ [key: string]: never }>;
-
-export type GetHorsesQuery = {
-    __typename?: 'Query';
-    horses: Array<{ __typename?: 'Horse'; id: string; name: string }>;
-};
-
-export type GetRidersQueryVariables = Exact<{ [key: string]: never }>;
-
-export type GetRidersQuery = {
-    __typename?: 'Query';
-    riders: Array<{ __typename?: 'Rider'; id: string; name: string }>;
-};
-
 export type GetDashboardDataQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetDashboardDataQuery = {
@@ -337,6 +323,13 @@ export type LoginMutation = {
     };
 };
 
+export type GetRidersQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GetRidersQuery = {
+    __typename?: 'Query';
+    riders: Array<{ __typename?: 'Rider'; id: string; name: string }>;
+};
+
 export type GetSessionForEditQueryVariables = Exact<{
     id: Scalars['ID']['input'];
 }>;
@@ -379,6 +372,29 @@ export type DeleteSessionMutation = {
     deleteSession: boolean;
 };
 
+export type GetSessionsQueryVariables = Exact<{
+    limit: InputMaybe<Scalars['Int']['input']>;
+    offset: InputMaybe<Scalars['Int']['input']>;
+    horseId: InputMaybe<Scalars['ID']['input']>;
+    workType: InputMaybe<WorkType>;
+    dateFrom: InputMaybe<Scalars['DateTime']['input']>;
+    dateTo: InputMaybe<Scalars['DateTime']['input']>;
+}>;
+
+export type GetSessionsQuery = {
+    __typename?: 'Query';
+    sessions: Array<{
+        __typename?: 'Session';
+        id: string;
+        date: any;
+        durationMinutes: number;
+        workType: WorkType;
+        notes: string;
+        horse: { __typename?: 'Horse'; id: string; name: string };
+        rider: { __typename?: 'Rider'; name: string };
+    }>;
+};
+
 export type SignupMutationVariables = Exact<{
     name: Scalars['String']['input'];
     email: Scalars['String']['input'];
@@ -392,4 +408,11 @@ export type SignupMutation = {
         token: string;
         rider: { __typename?: 'Rider'; id: string; name: string };
     };
+};
+
+export type GetHorsesQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GetHorsesQuery = {
+    __typename?: 'Query';
+    horses: Array<{ __typename?: 'Horse'; id: string; name: string }>;
 };

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -67,9 +67,17 @@ export default function Dashboard(): React.ReactNode {
 
                 {/* Recent Activity Section */}
                 <section>
-                    <h2 className="text-sm font-medium text-muted-foreground mb-3 px-1">
-                        Recent Activity
-                    </h2>
+                    <div className="flex items-center justify-between mb-3 px-1">
+                        <h2 className="text-sm font-medium text-muted-foreground">
+                            Recent Activity
+                        </h2>
+                        <button
+                            className="text-sm text-primary"
+                            onClick={() => push('/sessions')}
+                        >
+                            See all
+                        </button>
+                    </div>
                     <div className="space-y-3">
                         {data?.sessions.map((session) => (
                             <ActivityCard

--- a/packages/web/src/pages/HorseProfile.tsx
+++ b/packages/web/src/pages/HorseProfile.tsx
@@ -192,9 +192,23 @@ export default function HorseProfile(): React.ReactNode {
                     {/* Sessions list */}
                     <Separator />
                     <section>
-                        <h2 className="text-sm font-medium text-muted-foreground mb-3">
-                            Sessions
-                        </h2>
+                        <div className="flex items-center justify-between mb-3">
+                            <h2 className="text-sm font-medium text-muted-foreground">
+                                Sessions
+                            </h2>
+                            {sessions.length > 0 && (
+                                <button
+                                    className="text-sm text-primary"
+                                    onClick={() =>
+                                        push(
+                                            `/sessions?horseId=${id}&horseName=${encodeURIComponent(horse.name)}`
+                                        )
+                                    }
+                                >
+                                    View all sessions
+                                </button>
+                            )}
+                        </div>
                         {sessions.length === 0 ? (
                             <p className="text-sm text-muted-foreground">
                                 No sessions yet.

--- a/packages/web/src/pages/Sessions.tsx
+++ b/packages/web/src/pages/Sessions.tsx
@@ -44,6 +44,7 @@ const SESSIONS_QUERY = gql`
             workType
             notes
             horse {
+                id
                 name
             }
             rider {
@@ -59,7 +60,7 @@ interface SessionItem {
     durationMinutes: number;
     workType: string;
     notes: string;
-    horse: { name: string };
+    horse: { id: string; name: string };
     rider: { name: string };
 }
 


### PR DESCRIPTION
## Summary
- Add "See all" link next to "Recent Activity" heading on the dashboard → navigates to `/sessions`
- Add "View all sessions" link in the Sessions section of horse profile → navigates to `/sessions?horseId=X&horseName=Y`, pre-filtering the existing filter chips
- Add `horse.id` to the Sessions page query so the horse filter chip displays correctly

## Test plan
- [ ] Dashboard: tap "See all" → lands on sessions page with no filters active
- [ ] Horse profile: tap "View all sessions" → lands on sessions page with horse filter chip active showing the horse name
- [ ] Clearing the horse filter chip removes the URL params and shows all sessions

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)