### PR TITLE
feat(ci): smoke E2E on PRs, full suite on main, nightly cron

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,98 @@
+name: E2E Nightly
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # 6am UTC daily
+  workflow_dispatch:
+
+jobs:
+  e2e-regression:
+    name: Full Regression Suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm --filter e2e exec playwright --version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-all
+
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e exec playwright install --with-deps chromium webkit
+
+      - name: Install Playwright deps (cached)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter e2e exec playwright install-deps chromium webkit
+
+      - name: Build API
+        run: pnpm --filter api build
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+
+      - name: Build Web
+        run: pnpm --filter web build
+
+      - name: Start test database
+        run: docker compose -f docker-compose.test.yml up -d
+
+      - name: Wait for Postgres
+        run: |
+          timeout 30 bash -c 'until docker compose -f docker-compose.test.yml exec -T postgres pg_isready -U postgres; do sleep 1; done'
+
+      - name: Run migrations
+        run: |
+          DATABASE_URL=postgresql://postgres:test@localhost:5433/herdbook_test pnpm --filter api prisma:migrate:deploy
+
+      - name: Generate Prisma client
+        run: pnpm --filter api prisma:generate
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5433/herdbook_test
+
+      - name: Seed test data
+        run: |
+          DATABASE_URL=postgresql://postgres:test@localhost:5433/herdbook_test pnpm --filter api prisma:seed:e2e
+
+      - name: Run smoke tests
+        run: pnpm --filter e2e exec playwright test --config playwright.smoke.config.ts
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5433/herdbook_test
+          CI: true
+
+      - name: Run regression tests
+        run: pnpm --filter e2e exec playwright test --config playwright.regression.config.ts
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5433/herdbook_test
+          CI: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-nightly
+          path: packages/e2e/playwright-report/
+          retention-days: 30
+
+      - name: Stop test database
+        if: always()
+        run: docker compose -f docker-compose.test.yml down -v

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,9 @@ on:
     branches: [main]
 
 jobs:
-  e2e:
+  e2e-smoke:
+    if: github.event_name == 'pull_request'
+    name: Smoke Tests
     runs-on: ubuntu-latest
 
     steps:
@@ -26,8 +28,24 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm --filter e2e exec playwright --version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-chromium
+
       - name: Install Playwright browsers
-        run: pnpm --filter e2e exec playwright install --with-deps webkit
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e exec playwright install --with-deps chromium
+
+      - name: Install Playwright deps (cached)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter e2e exec playwright install-deps chromium
 
       - name: Build API
         run: pnpm --filter api build
@@ -57,8 +75,8 @@ jobs:
         run: |
           DATABASE_URL=postgresql://postgres:test@localhost:5433/herdbook_test pnpm --filter api prisma:seed:e2e
 
-      - name: Run E2E tests
-        run: pnpm test:e2e
+      - name: Run smoke tests
+        run: pnpm --filter e2e exec playwright test --config playwright.smoke.config.ts
         env:
           DATABASE_URL: postgresql://postgres:test@localhost:5433/herdbook_test
           CI: true
@@ -67,7 +85,99 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-smoke
+          path: packages/e2e/playwright-report/
+          retention-days: 30
+
+      - name: Stop test database
+        if: always()
+        run: docker compose -f docker-compose.test.yml down -v
+
+  e2e-full:
+    if: github.event_name == 'push'
+    name: Full E2E Suite
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(pnpm --filter e2e exec playwright --version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-all
+
+      - name: Install Playwright browsers
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter e2e exec playwright install --with-deps chromium webkit
+
+      - name: Install Playwright deps (cached)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter e2e exec playwright install-deps chromium webkit
+
+      - name: Build API
+        run: pnpm --filter api build
+        env:
+          DATABASE_URL: postgresql://dummy:dummy@localhost:5432/dummy
+
+      - name: Build Web
+        run: pnpm --filter web build
+
+      - name: Start test database
+        run: docker compose -f docker-compose.test.yml up -d
+
+      - name: Wait for Postgres
+        run: |
+          timeout 30 bash -c 'until docker compose -f docker-compose.test.yml exec -T postgres pg_isready -U postgres; do sleep 1; done'
+
+      - name: Run migrations
+        run: |
+          DATABASE_URL=postgresql://postgres:test@localhost:5433/herdbook_test pnpm --filter api prisma:migrate:deploy
+
+      - name: Generate Prisma client
+        run: pnpm --filter api prisma:generate
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5433/herdbook_test
+
+      - name: Seed test data
+        run: |
+          DATABASE_URL=postgresql://postgres:test@localhost:5433/herdbook_test pnpm --filter api prisma:seed:e2e
+
+      - name: Run smoke tests
+        run: pnpm --filter e2e exec playwright test --config playwright.smoke.config.ts
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5433/herdbook_test
+          CI: true
+
+      - name: Run regression tests
+        run: pnpm --filter e2e exec playwright test --config playwright.regression.config.ts
+        env:
+          DATABASE_URL: postgresql://postgres:test@localhost:5433/herdbook_test
+          CI: true
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-full
           path: packages/e2e/playwright-report/
           retention-days: 30
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,6 @@ packages/api/src/generated/prisma
 test-results/
 playwright-report/
 blob-report/
-playwright/.cache/
-playwright/.auth/
+**/playwright/.cache/
+**/playwright/.auth/
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Herdbook
 
+[![E2E Nightly](https://github.com/taco/herdbook/actions/workflows/e2e-nightly.yml/badge.svg)](https://github.com/taco/herdbook/actions/workflows/e2e-nightly.yml)
+
 A mobile-first training journal for equestrians. Log riding sessions by voice or form, track activity per horse, and review training patterns over time.
 
 ## What It Does
@@ -173,15 +175,30 @@ pnpm --filter web test
 
 ### E2E Tests
 
-E2E tests use Playwright and run against an isolated Docker Postgres instance.
+E2E tests use Playwright and run against an isolated Docker Postgres instance. Tests are split into two tiers:
+
+- **Smoke** (`tests/smoke/`) — critical path tests (auth, navigation). Chromium-only, parallel, fast.
+- **Regression** (`tests/regression/`) — full feature tests (horses, sessions). Chrome + Safari.
 
 ```bash
-# From root - runs full E2E suite
+# From root - runs all tests (smoke + regression)
 pnpm test:e2e
+
+# Smoke tests only
+pnpm --filter e2e exec playwright test --config playwright.smoke.config.ts
+
+# Regression tests only
+pnpm --filter e2e exec playwright test --config playwright.regression.config.ts
 
 # With Playwright UI for debugging
 pnpm --filter e2e test:ui
 ```
+
+**CI strategy:**
+
+- **Pull requests** run smoke tests only (fast feedback)
+- **Push to main** runs the full suite (smoke + regression)
+- **Nightly cron** runs the full suite on schedule
 
 **Prerequisites**: Docker must be running. The test suite automatically:
 

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -1,48 +1,44 @@
 import { defineConfig, devices } from '@playwright/test';
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+export const STORAGE_STATE = 'playwright/.auth/user.json';
 
 /**
+ * Base Playwright configuration — used for local development (runs all projects).
+ * CI uses playwright.smoke.config.ts and playwright.regression.config.ts instead.
+ *
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
     testDir: './tests',
-    /* Run tests in files in parallel */
     fullyParallel: false,
-    /* Fail the build on CI if you accidentally left test.only in the source code. */
     forbidOnly: !!process.env.CI,
-    /* Retry on CI only */
     retries: 0,
-    /* Opt out of parallel tests on CI. */
     workers: 1,
-    /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: [['list'], ['html', { open: 'never' }]],
-    /* Per-test timeout */
     timeout: 30 * 1000,
-    /* Global setup and teardown */
     globalSetup: './global-setup.ts',
     globalTeardown: './global-teardown.ts',
-    /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
-        /* Base URL to use in actions like `await page.goto('')`. */
         baseURL: 'http://127.0.0.1:3099',
-
-        /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
     },
 
-    /* Configure projects for major browsers */
     projects: [
+        {
+            name: 'smoke-setup',
+            testDir: './tests/smoke',
+            testMatch: /.*\.setup\.ts/,
+            use: { ...devices['Pixel 5'] },
+        },
         {
             name: 'smoke-chrome',
             testDir: './tests/smoke',
-            use: { ...devices['Pixel 5'] },
+            testIgnore: /.*\.setup\.ts/,
+            use: {
+                ...devices['Pixel 5'],
+                storageState: STORAGE_STATE,
+            },
+            dependencies: ['smoke-setup'],
         },
         {
             name: 'regression-chrome',
@@ -56,7 +52,6 @@ export default defineConfig({
         },
     ],
 
-    /* Run local dev server before starting the tests */
     webServer: [
         {
             command: 'pnpm --filter api dev',

--- a/packages/e2e/playwright.regression.config.ts
+++ b/packages/e2e/playwright.regression.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig, devices } from '@playwright/test';
+import baseConfig from './playwright.config';
+
+/**
+ * Regression test config — Chrome + Safari, sequential.
+ * Used by CI on push to main and nightly cron runs.
+ */
+export default defineConfig({
+    ...baseConfig,
+
+    projects: [
+        {
+            name: 'regression-chrome',
+            testDir: './tests/regression',
+            use: { ...devices['Pixel 5'] },
+        },
+        {
+            name: 'regression-safari',
+            testDir: './tests/regression',
+            use: { ...devices['iPhone 12'] },
+        },
+    ],
+});

--- a/packages/e2e/playwright.smoke.config.ts
+++ b/packages/e2e/playwright.smoke.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+import baseConfig, { STORAGE_STATE } from './playwright.config';
+
+/**
+ * Smoke test config — Chromium-only, parallel, with shared auth state.
+ * Used by CI on pull requests for fast feedback.
+ */
+export default defineConfig({
+    ...baseConfig,
+    workers: 2,
+    fullyParallel: true,
+
+    projects: [
+        {
+            name: 'smoke-setup',
+            testDir: './tests/smoke',
+            testMatch: /.*\.setup\.ts/,
+            use: { ...devices['Pixel 5'] },
+        },
+        {
+            name: 'smoke-chrome',
+            testDir: './tests/smoke',
+            testIgnore: /.*\.setup\.ts/,
+            use: {
+                ...devices['Pixel 5'],
+                storageState: STORAGE_STATE,
+            },
+            dependencies: ['smoke-setup'],
+        },
+    ],
+});

--- a/packages/e2e/tests/smoke/auth.setup.ts
+++ b/packages/e2e/tests/smoke/auth.setup.ts
@@ -1,0 +1,14 @@
+import { test as setup } from '@playwright/test';
+import { TEST_RIDER_EMAIL, TEST_RIDER_PASSWORD } from '@/seedConstants';
+
+const AUTH_FILE = 'playwright/.auth/user.json';
+
+setup('authenticate as test rider', async ({ page }) => {
+    await page.goto('/login');
+    await page.fill('input[id="email"]', TEST_RIDER_EMAIL);
+    await page.fill('input[id="password"]', TEST_RIDER_PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL('/');
+
+    await page.context().storageState({ path: AUTH_FILE });
+});

--- a/packages/e2e/tests/smoke/auth.spec.ts
+++ b/packages/e2e/tests/smoke/auth.spec.ts
@@ -1,10 +1,8 @@
 import { test, expect } from '@playwright/test';
 import { TEST_RIDER_EMAIL, TEST_RIDER_PASSWORD } from '@/seedConstants';
-import { resetDatabase } from '../utils/resetDatabase';
 
-test.beforeAll(() => {
-    resetDatabase();
-});
+// Auth tests need a clean browser state — they test the login/signup flows directly
+test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe('Authentication', () => {
     test('can log in with valid credentials', async ({ page }) => {

--- a/packages/e2e/tests/smoke/navigation.spec.ts
+++ b/packages/e2e/tests/smoke/navigation.spec.ts
@@ -1,22 +1,11 @@
 import { test, expect } from '@playwright/test';
-import {
-    TEST_RIDER_EMAIL,
-    TEST_RIDER_PASSWORD,
-    TEST_RIDER_NAME,
-    TEST_HORSE_NAME,
-} from '@/seedConstants';
-import { resetDatabase } from '../utils/resetDatabase';
+import { TEST_RIDER_NAME, TEST_HORSE_NAME } from '@/seedConstants';
 
-test.beforeAll(() => {
-    resetDatabase();
-});
+// storageState from smoke-setup handles auth — no manual login needed
 
 test.describe('Navigation', () => {
     test.beforeEach(async ({ page }) => {
-        await page.goto('/login');
-        await page.fill('input[id="email"]', TEST_RIDER_EMAIL);
-        await page.fill('input[id="password"]', TEST_RIDER_PASSWORD);
-        await page.click('button[type="submit"]');
+        await page.goto('/');
         await page.waitForURL('/');
     });
 


### PR DESCRIPTION
## Summary

- **PRs** run smoke tests only (Chromium, parallel, ~3s) for fast feedback
- **Push to main** runs full suite (smoke + regression, Chrome + Safari)
- **Nightly cron** (6am UTC) runs full regression with manual dispatch option
- Playwright browser caching in all CI workflows (~36s savings per run)
- `storageState` auth setup so smoke navigation tests skip login
- E2E Nightly status badge in README

Fixes #28, #29, #30, #31

## Test plan

- [x] Smoke tests pass locally (8 tests, 3.4s)
- [x] Regression tests pass locally (26 tests, 2m 18s)
- [ ] PR triggers `e2e-smoke` job (Chromium-only)
- [ ] Push to main triggers `e2e-full` job (Chrome + Safari)
- [ ] Manual dispatch of nightly workflow runs full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)