### PR TITLE
fix(e2e): use specific locator for prefilled horse assertion

### DIFF
--- a/packages/e2e/tests/regression/horse-profile.spec.ts
+++ b/packages/e2e/tests/regression/horse-profile.spec.ts
@@ -78,9 +78,9 @@ test.describe('Horse Profile', () => {
         await page.getByRole('button', { name: 'Log Session' }).click();
         await expect(page).toHaveURL('/sessions/new');
 
-        // Horse should be prefilled
+        // Horse should be prefilled in the summary row
         await expect(
-            page.getByText(TEST_HORSE_NAME, { exact: true })
-        ).toBeVisible();
+            page.getByRole('button', { name: 'Edit Horse' })
+        ).toContainText(TEST_HORSE_NAME);
     });
 });


### PR DESCRIPTION
## Summary
- Fixed nightly E2E regression failure in `horse-profile.spec.ts`
- `getByText('Test Horse', { exact: true })` resolved to 6 elements (page header h1 + 5 session card h3s), causing a Playwright strict mode violation
- Replaced with `getByRole('button', { name: 'Edit Horse' }).toContainText(...)` to target the specific summary row button

## Test plan
- [x] Ran failing test locally — passes on both Chrome and Safari