### PR TITLE
Fix screen dimming during voice recording

### DIFF
--- a/packages/web/src/components/voice/RecordingPanel.tsx
+++ b/packages/web/src/components/voice/RecordingPanel.tsx
@@ -6,6 +6,7 @@ interface RecordingPanelProps {
     isRecording: boolean;
     elapsedSeconds: number;
     maxDurationSeconds: number;
+    wakeLockActive: boolean;
     onStart: () => void;
     onStop: () => void;
     onCancel: () => void;
@@ -21,6 +22,7 @@ export default function RecordingPanel({
     isRecording,
     elapsedSeconds,
     maxDurationSeconds,
+    wakeLockActive,
     onStart,
     onStop,
     onCancel,
@@ -89,6 +91,14 @@ export default function RecordingPanel({
                     </span>
                 )}
             </div>
+
+            {/* Wake lock warning */}
+            {isRecording && !wakeLockActive && (
+                <p className="text-sm text-amber-600 text-center px-4">
+                    Keep your screen on — your device may sleep and stop
+                    recording
+                </p>
+            )}
 
             {/* Controls */}
             <div className="flex items-center gap-4">

--- a/packages/web/src/pages/VoiceSessionCapture.tsx
+++ b/packages/web/src/pages/VoiceSessionCapture.tsx
@@ -55,6 +55,7 @@ export default function VoiceSessionCapture() {
         parsedFields,
         error,
         canRetry,
+        wakeLockActive,
         startRecording,
         stopRecording,
         cancelRecording,
@@ -182,6 +183,7 @@ export default function VoiceSessionCapture() {
                         isRecording={isRecording}
                         elapsedSeconds={elapsedSeconds}
                         maxDurationSeconds={maxDurationSeconds}
+                        wakeLockActive={wakeLockActive}
                         onStart={startRecording}
                         onStop={stopRecording}
                         onCancel={cancelRecording}


### PR DESCRIPTION
## Summary
- Use the Wake Lock API to prevent the screen from sleeping during voice recording, which was killing the microphone on some devices
- Show an amber warning when the wake lock can't be acquired (e.g. Low Power Mode) so the user knows to keep the screen on manually
- Re-acquire the lock on `visibilitychange` for Safari, which releases it when the tab is backgrounded

## Test plan
- [x] Tested on iPhone — screen stays awake during recording
- [x] Verify warning appears in Low Power Mode
- [x] Verify recording still works normally on devices/browsers without Wake Lock API support

Fixes #35