### PR TITLE
Unify rate limiting across GraphQL and REST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ packages/api/src/generated/prisma
 
 # Claude Code
 .state
+.claude/settings.local.json
 
 # Local SSL certs
 *.pem

--- a/packages/api/src/config.ts
+++ b/packages/api/src/config.ts
@@ -128,10 +128,18 @@ export function getJwtExpiration(): SignOptions['expiresIn'] {
         '30 days') as SignOptions['expiresIn'];
 }
 
-export function getRateLimits(): { read: number; write: number; auth: number } {
+export function getRateLimits(): {
+    read: number;
+    write: number;
+    auth: number;
+    aiBurst: number;
+    aiDaily: number;
+} {
     return {
         read: Number(process.env.RATE_LIMIT_READ) || 120,
         write: Number(process.env.RATE_LIMIT_WRITE) || 30,
         auth: Number(process.env.RATE_LIMIT_AUTH) || 10,
+        aiBurst: Number(process.env.RATE_LIMIT_AI_BURST) || 2,
+        aiDaily: Number(process.env.RATE_LIMIT_AI_DAILY) || 20,
     };
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -5,6 +5,15 @@ import { createLoaders } from '@/graphql/loaders';
 import { getJwtSecretOrThrow } from '@/config';
 import type { Context } from '@/graphql/resolvers';
 
+/**
+ * Shared rate-limit key: rider ID from JWT, falling back to IP.
+ * Used by both GraphQL and REST rate limiters.
+ */
+export function rateLimitKey(req: FastifyRequest): string {
+    const auth = verifyToken(req.headers.authorization);
+    return auth ? `rider:${auth.riderId}` : `ip:${req.ip}`;
+}
+
 export async function buildContext(
     request: FastifyRequest,
     reply: FastifyReply

--- a/packages/api/src/rest/voice.ts
+++ b/packages/api/src/rest/voice.ts
@@ -1,8 +1,8 @@
-import type { FastifyInstance } from 'fastify';
+import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import OpenAI from 'openai';
-import jwt from 'jsonwebtoken';
 import type { WorkType } from '@prisma/client';
-import { getJwtSecretOrThrow } from '@/config';
+import { getRateLimits } from '@/config';
+import { rateLimitKey, verifyToken } from '@/middleware/auth';
 import { PROMPTS, type PromptName } from './voicePrompts';
 
 // Types for parse-session endpoint
@@ -135,69 +135,150 @@ export async function parseTranscript(
     return { parsed, raw, usage: completion.usage ?? undefined };
 }
 
+type RateLimitResult =
+    | { isAllowed: true; key: string }
+    | {
+          isAllowed: false;
+          key: string;
+          max: number;
+          timeWindow: number;
+          remaining: number;
+          ttl: number;
+          ttlInSeconds: number;
+          isExceeded: boolean;
+          isBanned: boolean;
+      };
+
+type Limiter = (req: FastifyRequest) => Promise<RateLimitResult>;
+
 /**
  * Register voice-related REST routes
  */
 export async function registerVoiceRoutes(app: FastifyInstance): Promise<void> {
-    // Parse session from voice input
-    app.post('/api/parse-session', async (request, reply) => {
-        // Authenticate user
-        const auth = request.headers.authorization;
-        if (!auth || !auth.startsWith('Bearer ')) {
-            return reply.status(401).send({ error: 'Unauthorized' });
-        }
+    const rateLimits = getRateLimits();
 
-        const token = auth.slice(7);
-        try {
-            jwt.verify(token, getJwtSecretOrThrow());
-        } catch {
-            return reply.status(401).send({ error: 'Invalid token' });
-        }
-
-        const parts = request.parts();
-        let audioBuffer: Buffer | null = null;
-        let audioMimeType = 'audio/webm';
-        let context: ParseSessionContext | null = null;
-
-        for await (const part of parts) {
-            if (part.type === 'file' && part.fieldname === 'audio') {
-                audioBuffer = await part.toBuffer();
-                audioMimeType = part.mimetype;
-            } else if (part.type === 'field' && part.fieldname === 'context') {
-                context = JSON.parse(
-                    part.value as string
-                ) as ParseSessionContext;
-            }
-        }
-
-        if (!audioBuffer) {
-            return reply.status(400).send({ error: 'No audio data provided' });
-        }
-        if (!context) {
-            return reply.status(400).send({ error: 'No context provided' });
-        }
-
-        try {
-            // Step 1: Transcribe audio
-            const transcript = await transcribeAudio(
-                audioBuffer,
-                audioMimeType
-            );
-
-            // Step 2: Parse transcript into structured fields
-            const { parsed } = await parseTranscript(transcript, context);
-
-            return {
-                notes: transcript,
-                ...parsed,
-            };
-        } catch (error) {
-            console.error('Parse session error:', error);
-            return reply.status(500).send({
-                error: 'Failed to parse session',
-                details:
-                    error instanceof Error ? error.message : 'Unknown error',
-            });
-        }
+    // Per-endpoint burst limiter
+    const burstLimiter: Limiter = app.createRateLimit({
+        max: rateLimits.aiBurst,
+        timeWindow: '1 minute',
+        keyGenerator: rateLimitKey,
     });
+
+    // Shared daily limiter — decorator so future AI endpoints share the same pool
+    if (!app.hasDecorator('aiDailyLimiter')) {
+        app.decorate(
+            'aiDailyLimiter',
+            app.createRateLimit({
+                max: rateLimits.aiDaily,
+                timeWindow: '1 day',
+                keyGenerator: rateLimitKey,
+            })
+        );
+    }
+    const dailyLimiter = (app as any).aiDailyLimiter as Limiter;
+
+    type Handler = (
+        request: FastifyRequest,
+        reply: FastifyReply
+    ) => Promise<unknown>;
+
+    // Wrapper HOF — mirrors wrapResolver('read', fn) in resolvers.ts
+    const wrapHandler =
+        (bucket: string, handler: Handler): Handler =>
+        async (request: FastifyRequest, reply: FastifyReply) => {
+            const limiters: Array<[string, Limiter]> = [
+                ['burst', burstLimiter],
+                ['daily', dailyLimiter],
+            ];
+            for (const [name, limiter] of limiters) {
+                const rl = await limiter(request);
+                if (!rl.isAllowed && rl.isExceeded) {
+                    const key = rateLimitKey(request);
+                    console.warn(
+                        `[rest:rate-limit] ${bucket}:${name} exceeded for ${request.url} — key=${key}, ttl=${rl.ttl}s`
+                    );
+                    const message =
+                        name === 'daily'
+                            ? "You've reached your daily limit for AI features. Please try again tomorrow."
+                            : 'Too many requests. Please wait a moment and try again.';
+                    return reply.status(429).send({
+                        error: 'RATE_LIMITED',
+                        message,
+                        rateLimit: {
+                            bucket: `${bucket}:${name}`,
+                            ttl: rl.ttl,
+                            remaining: rl.remaining,
+                        },
+                    });
+                }
+            }
+            return handler(request, reply);
+        };
+
+    app.post(
+        '/api/parse-session',
+        wrapHandler('ai', async (request, reply) => {
+            // Authenticate user
+            const authHeader = request.headers.authorization;
+            if (!authHeader || !authHeader.startsWith('Bearer ')) {
+                return reply.status(401).send({ error: 'Unauthorized' });
+            }
+            if (!verifyToken(authHeader)) {
+                return reply.status(401).send({ error: 'Invalid token' });
+            }
+
+            const parts = request.parts();
+            let audioBuffer: Buffer | null = null;
+            let audioMimeType = 'audio/webm';
+            let context: ParseSessionContext | null = null;
+
+            for await (const part of parts) {
+                if (part.type === 'file' && part.fieldname === 'audio') {
+                    audioBuffer = await part.toBuffer();
+                    audioMimeType = part.mimetype;
+                } else if (
+                    part.type === 'field' &&
+                    part.fieldname === 'context'
+                ) {
+                    context = JSON.parse(
+                        part.value as string
+                    ) as ParseSessionContext;
+                }
+            }
+
+            if (!audioBuffer) {
+                return reply
+                    .status(400)
+                    .send({ error: 'No audio data provided' });
+            }
+            if (!context) {
+                return reply.status(400).send({ error: 'No context provided' });
+            }
+
+            try {
+                // Step 1: Transcribe audio
+                const transcript = await transcribeAudio(
+                    audioBuffer,
+                    audioMimeType
+                );
+
+                // Step 2: Parse transcript into structured fields
+                const { parsed } = await parseTranscript(transcript, context);
+
+                return {
+                    notes: transcript,
+                    ...parsed,
+                };
+            } catch (error) {
+                console.error('Parse session error:', error);
+                return reply.status(500).send({
+                    error: 'Failed to parse session',
+                    details:
+                        error instanceof Error
+                            ? error.message
+                            : 'Unknown error',
+                });
+            }
+        })
+    );
 }

--- a/packages/web/src/hooks/useRecordingStateMachine.ts
+++ b/packages/web/src/hooks/useRecordingStateMachine.ts
@@ -157,9 +157,12 @@ export function useRecordingStateMachine({
                 if (!response.ok) {
                     const errorData = (await response.json()) as {
                         error: string;
+                        message?: string;
                     };
                     throw new Error(
-                        errorData.error || 'Failed to parse session'
+                        errorData.message ||
+                            errorData.error ||
+                            'Failed to parse session'
                     );
                 }
 


### PR DESCRIPTION
## Summary
- Add shared `rateLimitKey()` to auth middleware, reused by both GraphQL resolvers and REST endpoints (rider ID from JWT with IP fallback)
- Replace broken `keyByUserOrIp` closure in GraphQL resolvers (`req.rider?.id` was never set, always fell back to IP)
- Rewrite voice endpoint rate limiting from declarative to programmatic `createRateLimit()` + `wrapHandler` HOF, mirroring the GraphQL `wrapResolver` pattern
- Add two-tier AI cost control: per-endpoint burst (2/min) + shared daily cap (20/day) via Fastify decorator
- Client now shows human-readable rate limit messages instead of error codes

## Test plan
- [x] Existing rate limit tests pass (auth bucket: GraphQL login/signup)
- [x] New AI burst limit test: 3 requests with limit of 2, verifies 429 with `ai:burst` bucket
- [x] New AI daily limit test: 4 requests with limit of 3, verifies 429 with `ai:daily` bucket
- [x] TypeScript compiles cleanly
- [x] All 24 tests pass (16 API + 8 web)

Closes #35