### PR TITLE
feat(web): disable overscroll bounce, long-press menu, and standalone PWA display

### DIFF
--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -82,8 +82,13 @@
     * {
         @apply border-border;
     }
+    html,
+    body {
+        overscroll-behavior: none;
+    }
     body {
         @apply bg-background text-foreground;
+        -webkit-touch-callout: none;
     }
 }
 

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
                 name: 'Herdbook',
                 short_name: 'Herdbook',
                 description: 'Horse management application',
+                display: 'standalone',
                 theme_color: '#ffffff',
                 icons: [
                     {


### PR DESCRIPTION
## Summary

- `overscroll-behavior: none` on `html, body` — stops elastic bounce (iOS Safari 16+) and pull-to-refresh / overscroll glow on Android Chrome
- `-webkit-touch-callout: none` on `body` — suppresses the long-press Copy/Share/Look Up context menu on iOS Safari
- `display: standalone` in PWA manifest — home screen installs open without browser chrome

## Notes

Pinch-to-zoom via viewport `user-scalable=no` was explored but dropped — iOS Safari 10+ ignores it by design for accessibility. The three changes here are the effective subset.

Fixes #56