### PR TITLE
feat(deploy): add railway.toml with automatic migrations

### DIFF
--- a/.claude/skills/deploy-preview/SKILL.md
+++ b/.claude/skills/deploy-preview/SKILL.md
@@ -58,6 +58,10 @@ Override variables for both services:
 
 ### 4. Run migrations against Neon branch
 
+> **Note:** Production migrations are automatic via `packages/api/railway.toml` (`preDeployCommand`).
+> This manual step is only needed for preview environments, which use dynamic Neon branches
+> that don't exist in the production Railway config.
+
 ```bash
 DATABASE_URL="<neon-branch-url>" pnpm --filter api run prisma:migrate:deploy
 ```

--- a/packages/api/railway.toml
+++ b/packages/api/railway.toml
@@ -1,0 +1,7 @@
+[build]
+buildCommand = "pnpm run build"
+watchPatterns = ["packages/api/**", "pnpm-lock.yaml"]
+
+[deploy]
+startCommand = "pnpm run start"
+preDeployCommand = "pnpm run prisma:migrate:deploy"

--- a/packages/web/railway.toml
+++ b/packages/web/railway.toml
@@ -1,0 +1,6 @@
+[build]
+buildCommand = "pnpm run build"
+watchPatterns = ["packages/web/**", "pnpm-lock.yaml"]
+
+[deploy]
+startCommand = "pnpm run start"


### PR DESCRIPTION
## Summary
- Add `railway.toml` for both API and web services with scoped `watchPatterns`
- API `preDeployCommand` runs `prisma migrate deploy` on every deploy, preventing the production outage from #60
- Update deploy-preview skill docs to clarify manual vs automatic migration steps

## Test plan
- [ ] Verify `railway.toml` syntax is valid on next Railway deploy
- [ ] Confirm API deploy logs show `prisma migrate deploy` running before app start
- [ ] Confirm web-only changes don't trigger API redeploy (and vice versa)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)