### PR TITLE
fix(deploy): scope railway.toml commands to correct workspace package

### DIFF
--- a/packages/api/railway.toml
+++ b/packages/api/railway.toml
@@ -1,7 +1,7 @@
 [build]
-buildCommand = "pnpm run build"
+buildCommand = "pnpm run build:api"
 watchPatterns = ["packages/api/**", "pnpm-lock.yaml"]
 
 [deploy]
-startCommand = "pnpm run start"
+startCommand = "pnpm --filter api run start"
 preDeployCommand = "pnpm run prisma:migrate:deploy"

--- a/packages/web/railway.toml
+++ b/packages/web/railway.toml
@@ -1,6 +1,6 @@
 [build]
-buildCommand = "pnpm run build"
+buildCommand = "pnpm run build:web"
 watchPatterns = ["packages/web/**", "pnpm-lock.yaml"]
 
 [deploy]
-startCommand = "pnpm run start"
+startCommand = "pnpm --filter web run start"


### PR DESCRIPTION
## Summary
- Use `build:api` / `build:web` root scripts instead of `pnpm run build` so each service only builds its own package
- Use `pnpm --filter` for start commands since no root `start` script exists
- Fixes web build failing because root `build` also builds API (which needs `DATABASE_URL`)
- Fixes API start failing because there's no root `start` script

Follow-up to #65.

## Test plan
- [ ] Verify API deploys successfully with `prisma migrate deploy` in pre-deploy logs
- [ ] Verify web builds without `DATABASE_URL` in its environment
- [ ] Confirm both services start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)