### PR TITLE
chore: add branch prefix conventions and rebase-pr skill

### DIFF
--- a/.claude/skills/fixup/SKILL.md
+++ b/.claude/skills/fixup/SKILL.md
@@ -1,0 +1,82 @@
+---
+description: Stage, fixup-commit, autosquash rebase, and force-push in one step. For temporary commits that get folded into previous work.
+context: fork
+disable-model-invocation: true
+allowed-tools: Bash, Read
+---
+
+# /fixup — Squash into Previous Commits
+
+## Usage
+
+- `/fixup` — fixup and squash into the previous commit, then force-push
+- `/fixup N` — fixup and squash into the Nth commit back, then force-push
+
+Default N is 1 (the most recent commit).
+
+## Behavior
+
+### 1. Validate
+
+Check there are changes to stage:
+
+```bash
+git status --porcelain
+```
+
+If clean, tell the user there's nothing to fixup.
+
+### 2. Determine target commit
+
+```bash
+# N defaults to 1
+git log --oneline -N
+```
+
+The target is the Nth commit back from HEAD. Capture its SHA:
+
+```bash
+TARGET_SHA=$(git rev-parse HEAD~$((N-1)))
+```
+
+Show the user which commit will be squashed into:
+
+```bash
+git log --oneline -1 $TARGET_SHA
+```
+
+### 3. Stage and commit
+
+```bash
+git add -A
+git commit --fixup=$TARGET_SHA
+```
+
+### 4. Autosquash rebase
+
+Use `GIT_SEQUENCE_EDITOR=true` to run the interactive rebase non-interactively:
+
+```bash
+GIT_SEQUENCE_EDITOR=true git rebase -i --autosquash HEAD~$((N+1))
+```
+
+If the rebase fails (conflicts), abort and tell the user:
+
+```bash
+git rebase --abort
+```
+
+### 5. Force-push
+
+```bash
+git push --force-with-lease
+```
+
+If the push fails (e.g., no upstream), tell the user and suggest `git push -u origin <branch>`.
+
+## Example
+
+```
+/fixup      # squash into HEAD~0 (last commit)
+/fixup 3    # squash into HEAD~2 (3rd commit back)
+```

--- a/.claude/skills/rebase-pr/SKILL.md
+++ b/.claude/skills/rebase-pr/SKILL.md
@@ -1,0 +1,33 @@
+---
+description: Fetch, rebase on origin/main, resolve conflicts, push, and open a PR
+allowed-tools: Bash(git checkout:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git diff:*), Bash(git log:*), Bash(gh pr create:*), Read, Edit
+context: fork
+disable-model-invocation: true
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff (staged and unstaged changes): !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -10`
+
+## Your task
+
+Based on the above changes:
+
+1. **Branch**: Create a new branch if on main
+2. **Commit**: Stage changes and create a single commit with an appropriate message following conventional commits
+3. **Fetch**: Run `git fetch origin` to get the latest remote state
+4. **Rebase**: Run `git rebase origin/main` to rebase onto the latest main
+5. **Resolve conflicts**: If the rebase produces conflicts:
+    - Run `git status` to identify conflicting files
+    - Read each conflicting file to understand the conflict markers
+    - Edit each file to resolve the conflict, preserving the intent of both sides
+    - Stage resolved files with `git add`
+    - Run `git rebase --continue` to proceed
+    - Repeat until the rebase completes
+6. **Push**: Push the branch to origin. Use `--force-with-lease` if the rebase rewrote history (it almost always will)
+7. **PR**: Create a pull request using `gh pr create`
+
+If there are no conflicts, steps 1-4 and 6-7 should all be done as fast as possible in minimal messages. Only slow down if conflict resolution is needed.

--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -64,16 +64,25 @@ gh issue view <number> --json title,body,labels,comments,assignees
 Display a brief summary (title + labels). Use the title and labels to derive names:
 
 - Slugify the title (lowercase, hyphens, max ~40 chars): e.g. "Add horse filtering" → `add-horse-filtering`
-- Branch prefix from labels: `fix/` if bug label, `feat/` otherwise
-- Branch: `feat/<slug>` or `fix/<slug>`
+- Branch prefix from labels (first match wins):
+    - `bug` → `fix/`
+    - `documentation` → `docs/`
+    - `chore` or `maintenance` → `chore/`
+    - `refactor` → `refactor/`
+    - No matching label → `feat/`
+- Branch: `<prefix><slug>` (e.g. `fix/login-crash`, `chore/add-sentry`)
 - Path: `../herdbook-<slug>`
 
 #### From a name (non-numeric argument)
 
-Use the argument directly as the slug (lowercase, hyphens):
+If the argument contains a recognized prefix (`feat/`, `fix/`, `chore/`, `docs/`, `refactor/`), use it as-is:
 
-- Branch: `feat/<slug>`
-- Path: `../herdbook-<slug>`
+- `/worktree chore/add-sentry` → Branch: `chore/add-sentry`, Path: `../herdbook-add-sentry`
+- `/worktree docs/update-readme` → Branch: `docs/update-readme`, Path: `../herdbook-update-readme`
+
+If no recognized prefix, default to `feat/`:
+
+- `/worktree some-feature` → Branch: `feat/some-feature`, Path: `../herdbook-some-feature`
 
 ### 3. Create worktree
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,23 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--max-turns 5"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,11 @@ Example:
 
 - Conventional commits: `type(scope): description`
 - Types: `feat`, `fix`, `refactor`, `chore`, `docs`
+    - `feat`: user-facing capability (new feature, new page, new endpoint)
+    - `fix`: bug fix
+    - `chore`: infrastructure, tooling, CI, dependencies, monitoring (e.g., adding Sentry)
+    - `docs`: documentation only
+    - `refactor`: code restructuring, no behavior change
 - Prefer `git add <file>` over `git add .`
 - Do not add any co-author lines in commit messages
 - The top message should be short and easy to read without losing context
@@ -111,6 +116,7 @@ Use these skills for common workflows. Invoke with `/skillname` or the Skill too
 | Update docs after changes          | `/updatedocs`     |
 | Implement a GitHub issue           | `/gh-issue`       |
 | Write a well-scoped GitHub issue   | `/write-issue`    |
+| Fixup-squash into previous commits | `/fixup`          |
 
 ## New Feature Workflow
 


### PR DESCRIPTION
## Summary
- Expand the `/worktree` skill to derive branch prefixes (`fix/`, `docs/`, `chore/`, `refactor/`) from GitHub issue labels, and support explicit prefixes in named worktree arguments
- Add commit type definitions (`feat`, `fix`, `chore`, `docs`, `refactor`) to CLAUDE.md for agent clarity
- Add new `/rebase-pr` skill that automates branch creation, commit, rebase, push, and PR creation
- Add Claude code review GitHub Actions workflow

## Test plan
- [ ] Verify `/worktree 123` derives correct prefix from issue labels
- [ ] Verify `/worktree chore/add-sentry` uses prefix as-is
- [ ] Verify `/worktree some-feature` defaults to `feat/` prefix
- [ ] Verify rebase-pr skill completes full workflow without errors