### PR TITLE
Fix session deletion: stale cache and incorrect back-navigation

### DIFF
--- a/packages/web/src/pages/SessionDetail.tsx
+++ b/packages/web/src/pages/SessionDetail.tsx
@@ -192,13 +192,26 @@ export default function SessionDetail(): React.ReactNode {
             await deleteSession({
                 variables: { id: id! },
                 update(cache) {
+                    cache.evict({
+                        id: cache.identify({
+                            __typename: 'Session',
+                            id: id!,
+                        }),
+                    });
+                    cache.evict({ fieldName: 'horse' });
+                    cache.evict({ fieldName: 'horses' });
                     cache.evict({ fieldName: 'sessions' });
                     cache.evict({ fieldName: 'session' });
                     cache.evict({ fieldName: 'lastSessionForHorse' });
                     cache.gc();
                 },
             });
-            backTo('/');
+            // React Router stores a 0-based index; idx > 0 means in-app history exists
+            if (window.history.state?.idx > 0) {
+                back();
+            } else {
+                backTo('/');
+            }
         } catch (err) {
             setFormError(
                 err instanceof Error ? err.message : 'An error occurred'


### PR DESCRIPTION
## Summary
- Evict the normalized `Session` cache entry and horse-related query fields (`horse`, `horses`) on deletion so the horse profile (session list, activity heatmap, stats) and dashboard activity update immediately
- Replace `backTo('/')` with `back()` so the user returns to wherever they navigated from instead of always landing on the dashboard

fixes #48

## Test plan
- [x] Delete a session from horse profile → session disappears from list/heatmap/stats without refresh, user returns to horse profile
- [x] Delete a session from dashboard → recent activity updates without refresh, user returns to dashboard
- [x] Delete a session from sessions list → user returns to sessions list

🤖 Generated with [Claude Code](https://claude.com/claude-code)