### PR TITLE
fix(e2e): assign TRAINER role to seed rider

### DIFF
--- a/packages/api/prisma/seedE2E.ts
+++ b/packages/api/prisma/seedE2E.ts
@@ -24,7 +24,7 @@ async function seedE2E() {
         const hashedPassword = await bcrypt.hash(testRiderPassword, 10);
         rider = await prisma.rider.update({
             where: { id: existingRider.id },
-            data: { password: hashedPassword },
+            data: { password: hashedPassword, role: 'TRAINER' },
         });
     } else {
         const hashedPassword = await bcrypt.hash(testRiderPassword, 10);
@@ -33,6 +33,7 @@ async function seedE2E() {
                 name: TEST_RIDER_NAME,
                 email: testRiderEmail,
                 password: hashedPassword,
+                role: 'TRAINER',
             },
         });
     }


### PR DESCRIPTION
## Summary
- E2E horse tests (create, edit, deactivate) were failing because the seed rider defaulted to `RIDER` role
- The `EditHorse` guard redirects non-trainers away from `/horses/new`, so the form never rendered
- Added `role: 'TRAINER'` to both the create and update branches in `seedE2E.ts`

## Test plan
- [x] `pnpm run check` passes (format + typecheck)
- [x] All 4 horse regression tests pass (Chrome + Safari)