### PR TITLE
feat(api): scope all queries and mutations to barn

### DIFF
--- a/packages/api/src/loaders.test.ts
+++ b/packages/api/src/loaders.test.ts
@@ -167,8 +167,8 @@ describe('DataLoader batching', () => {
             q.toUpperCase().includes('"RIDER"')
         );
 
-        // Should have exactly 1 horse query and 1 rider query (batched)
-        expect(horseQueries.length).toBe(1);
+        // 1 horse query for DataLoader batch + 1 from sessions WHERE horse.barnId (barn scoping)
+        expect(horseQueries.length).toBeLessThanOrEqual(2);
         expect(riderQueries.length).toBeLessThanOrEqual(2); // 1 for batch, possibly 1 for auth context
 
         // Verify the horse query uses IN clause (batching)

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -25,6 +25,7 @@ export async function buildContext(
         loaders: createLoaders(),
     };
     if (!auth || !auth.startsWith('Bearer ')) {
+        await prisma.$executeRaw`SELECT set_config('app.current_barn_id', '', false)`;
         return context;
     }
 
@@ -38,10 +39,13 @@ export async function buildContext(
             omit: { password: true },
         });
         context.rider = rider;
+        const barnId = rider?.barnId ?? '';
+        await prisma.$executeRaw`SELECT set_config('app.current_barn_id', ${barnId}, false)`;
         return context;
     } catch (error) {
         // Avoid failing the whole request if auth is invalid.
         console.error('Error verifying token:', error);
+        await prisma.$executeRaw`SELECT set_config('app.current_barn_id', '', false)`;
         return context;
     }
 }

--- a/packages/api/src/test/access/barnIsolation.access.test.ts
+++ b/packages/api/src/test/access/barnIsolation.access.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+import type { FastifyInstance } from 'fastify';
+
+import { prisma } from '@/db';
+import { getJwtSecretOrThrow } from '@/config';
+import { createApiApp } from '@/server';
+import { seedBarn } from '@/test/setupWorld';
+import {
+    GET_HORSES,
+    GET_RIDERS,
+    GET_SESSIONS,
+    GET_HORSE,
+    GET_SESSION,
+    GET_LAST_SESSION_FOR_HORSE,
+    CREATE_SESSION,
+    UPDATE_HORSE,
+    UPDATE_SESSION,
+    DELETE_SESSION,
+} from '@/test/queries';
+
+type GqlResponse<T = Record<string, unknown>> = {
+    data?: T;
+    errors?: Array<{
+        message: string;
+        extensions?: { code?: string };
+    }>;
+};
+
+function makeGql(
+    fastify: FastifyInstance,
+    token: string
+): <T = Record<string, unknown>>(
+    query: string,
+    variables?: Record<string, unknown>
+) => Promise<GqlResponse<T>> {
+    return async <T = Record<string, unknown>>(
+        query: string,
+        variables?: Record<string, unknown>
+    ): Promise<GqlResponse<T>> => {
+        const response = await fastify.inject({
+            method: 'POST',
+            url: '/graphql',
+            headers: {
+                'content-type': 'application/json',
+                authorization: `Bearer ${token}`,
+            },
+            payload: { query, variables },
+        });
+        return JSON.parse(response.body) as GqlResponse<T>;
+    };
+}
+
+describe('cross-barn isolation', () => {
+    let fastify: FastifyInstance;
+
+    // Barn A entities
+    let barnAId: string;
+    let riderAId: string;
+    let gqlA: ReturnType<typeof makeGql>;
+    let horseAId: string;
+    let sessionAId: string;
+
+    // Barn B entities
+    let barnBId: string;
+    let riderBId: string;
+    let gqlB: ReturnType<typeof makeGql>;
+    let horseBId: string;
+    let sessionBId: string;
+
+    beforeAll(async () => {
+        fastify = await createApiApp();
+
+        // Create two barns
+        const barnA = await seedBarn('isolation-barn-a');
+        const barnB = await seedBarn('isolation-barn-b');
+        barnAId = barnA.id;
+        barnBId = barnB.id;
+
+        const hashedPassword = await bcrypt.hash('testpassword', 10);
+
+        // Seed rider+horse+session in each barn
+        const riderA = await prisma.rider.create({
+            data: {
+                name: 'Isolation A',
+                email: `isolation-a-${Date.now()}@test.herdbook`,
+                password: hashedPassword,
+                barnId: barnAId,
+                role: 'TRAINER',
+            },
+        });
+        riderAId = riderA.id;
+        const tokenA = jwt.sign({ riderId: riderA.id }, getJwtSecretOrThrow(), {
+            expiresIn: '1h',
+        });
+        gqlA = makeGql(fastify, tokenA);
+
+        const riderB = await prisma.rider.create({
+            data: {
+                name: 'Isolation B',
+                email: `isolation-b-${Date.now()}@test.herdbook`,
+                password: hashedPassword,
+                barnId: barnBId,
+                role: 'TRAINER',
+            },
+        });
+        riderBId = riderB.id;
+        const tokenB = jwt.sign({ riderId: riderB.id }, getJwtSecretOrThrow(), {
+            expiresIn: '1h',
+        });
+        gqlB = makeGql(fastify, tokenB);
+
+        const horseA = await prisma.horse.create({
+            data: { name: 'isolation-horse-a', barnId: barnAId },
+        });
+        horseAId = horseA.id;
+
+        const horseB = await prisma.horse.create({
+            data: { name: 'isolation-horse-b', barnId: barnBId },
+        });
+        horseBId = horseB.id;
+
+        const sessionA = await prisma.session.create({
+            data: {
+                horseId: horseAId,
+                riderId: riderAId,
+                date: new Date(),
+                durationMinutes: 30,
+                workType: 'FLATWORK',
+                notes: 'barn A session',
+            },
+        });
+        sessionAId = sessionA.id;
+
+        const sessionB = await prisma.session.create({
+            data: {
+                horseId: horseBId,
+                riderId: riderBId,
+                date: new Date(),
+                durationMinutes: 30,
+                workType: 'FLATWORK',
+                notes: 'barn B session',
+            },
+        });
+        sessionBId = sessionB.id;
+    });
+
+    afterAll(async () => {
+        await prisma.session.deleteMany({
+            where: { riderId: { in: [riderAId, riderBId] } },
+        });
+        await prisma.horse.deleteMany({
+            where: { id: { in: [horseAId, horseBId] } },
+        });
+        await prisma.rider.deleteMany({
+            where: { id: { in: [riderAId, riderBId] } },
+        });
+        await prisma.barn.deleteMany({
+            where: { id: { in: [barnAId, barnBId] } },
+        });
+        await fastify.close();
+        await prisma.$disconnect();
+    });
+
+    // ── List isolation ────────────────────────────────────────────────
+
+    it('horses list excludes other barn', async () => {
+        const res = await gqlA<{ horses: Array<{ id: string }> }>(GET_HORSES);
+        const ids = res.data!.horses.map((h) => h.id);
+        expect(ids).toContain(horseAId);
+        expect(ids).not.toContain(horseBId);
+    });
+
+    it('riders list excludes other barn', async () => {
+        const res = await gqlA<{ riders: Array<{ id: string }> }>(GET_RIDERS);
+        const ids = res.data!.riders.map((r) => r.id);
+        expect(ids).toContain(riderAId);
+        expect(ids).not.toContain(riderBId);
+    });
+
+    it('sessions list excludes other barn', async () => {
+        const res = await gqlA<{ sessions: Array<{ id: string }> }>(
+            GET_SESSIONS,
+            { limit: 100 }
+        );
+        const ids = res.data!.sessions.map((s) => s.id);
+        expect(ids).toContain(sessionAId);
+        expect(ids).not.toContain(sessionBId);
+    });
+
+    // ── Lookup isolation ──────────────────────────────────────────────
+
+    it('horse lookup returns null for other barn', async () => {
+        const res = await gqlA<{ horse: { id: string } | null }>(GET_HORSE, {
+            id: horseBId,
+        });
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.horse).toBeNull();
+    });
+
+    it('session lookup returns null for other barn', async () => {
+        const res = await gqlA<{ session: { id: string } | null }>(
+            GET_SESSION,
+            { id: sessionBId }
+        );
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.session).toBeNull();
+    });
+
+    it('lastSessionForHorse returns null for other barn', async () => {
+        const res = await gqlA<{
+            lastSessionForHorse: { id: string } | null;
+        }>(GET_LAST_SESSION_FOR_HORSE, { horseId: horseBId });
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.lastSessionForHorse).toBeNull();
+    });
+
+    // ── Mutation isolation ────────────────────────────────────────────
+
+    it('updateHorse rejects cross-barn horse', async () => {
+        const res = await gqlA(UPDATE_HORSE, {
+            id: horseBId,
+            name: 'hacked',
+        });
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('NOT_FOUND');
+    });
+
+    it('createSession rejects cross-barn horse', async () => {
+        const res = await gqlA(CREATE_SESSION, {
+            horseId: horseBId,
+            date: new Date().toISOString(),
+            durationMinutes: 30,
+            workType: 'FLATWORK',
+            notes: 'cross-barn attempt',
+        });
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('NOT_FOUND');
+    });
+
+    it('updateSession rejects cross-barn session', async () => {
+        const res = await gqlA(UPDATE_SESSION, {
+            id: sessionBId,
+            notes: 'hacked',
+        });
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('NOT_FOUND');
+    });
+
+    it('deleteSession rejects cross-barn session', async () => {
+        const res = await gqlA(DELETE_SESSION, { id: sessionBId });
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('NOT_FOUND');
+    });
+});

--- a/packages/api/src/test/access/queries.access.test.ts
+++ b/packages/api/src/test/access/queries.access.test.ts
@@ -93,8 +93,7 @@ describe('read queries access', () => {
         expect(res.data!.horse!.id).toBe(world.horse.id);
     });
 
-    // TODO(#85): sessions query is unscoped — will be barn-scoped
-    it('sessions returns other riders data (unscoped query)', async () => {
+    it('sessions returns same-barn rider data (barn-scoped)', async () => {
         const res = await world.userB.gql<{
             sessions: Array<{ id: string }>;
         }>(GET_SESSIONS, { limit: 100 });

--- a/packages/api/src/test/queries.ts
+++ b/packages/api/src/test/queries.ts
@@ -140,6 +140,18 @@ export const GET_HORSE = /* GraphQL */ `
     }
 `;
 
+export const GET_LAST_SESSION_FOR_HORSE = /* GraphQL */ `
+    query LastSessionForHorse($horseId: ID!) {
+        lastSessionForHorse(horseId: $horseId) {
+            id
+            date
+            durationMinutes
+            workType
+            notes
+        }
+    }
+`;
+
 export const GET_SESSION = /* GraphQL */ `
     query Session($id: ID!) {
         session(id: $id) {

--- a/packages/api/src/test/setupWorld.ts
+++ b/packages/api/src/test/setupWorld.ts
@@ -33,6 +33,7 @@ export type AnonActor = {
 };
 
 export type World = {
+    barnId: string;
     userA: Actor;
     userB: Actor;
     asAnon: AnonActor;
@@ -181,6 +182,7 @@ export async function setupWorld(suiteId: string): Promise<World> {
     }
 
     return {
+        barnId: barn.id,
         userA,
         userB,
         asAnon,

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -44,11 +44,13 @@ export default defineConfig({
             name: 'regression-chrome',
             testDir: './tests/regression',
             use: { ...devices['Pixel 5'] },
+            dependencies: ['smoke-chrome'],
         },
         {
             name: 'regression-safari',
             testDir: './tests/regression',
             use: { ...devices['iPhone 12'] },
+            dependencies: ['smoke-chrome'],
         },
     ],
 

--- a/packages/e2e/tests/utils/resetDatabase.ts
+++ b/packages/e2e/tests/utils/resetDatabase.ts
@@ -9,7 +9,7 @@ const DATABASE_URL = 'postgresql://postgres:test@127.0.0.1:5433/herdbook_test';
 
 export function resetDatabase(): void {
     execSync(
-        `psql "${DATABASE_URL}" -c 'TRUNCATE TABLE "Session", "Horse", "Rider" CASCADE'`,
+        `psql "${DATABASE_URL}" -c 'TRUNCATE TABLE "Session", "Horse", "Rider", "Barn" CASCADE'`,
         { stdio: 'pipe' }
     );
     execSync('pnpm --filter api prisma:seed:e2e', {


### PR DESCRIPTION
## Summary

Closes #85

- Add `requireAuth` helper returning `barnId` or throwing `UNAUTHENTICATED`
- Scope 6 queries (`horses`, `riders`, `sessions`, `horse`, `session`, `lastSessionForHorse`) to filter by rider's barn
- Scope 4 mutations (`updateHorse`, `createSession`, `updateSession`, `deleteSession`) to verify entities belong to rider's barn
- Set `app.current_barn_id` via `set_config()` in `buildContext` as RLS backstop
- Scope `horseSummary` REST endpoint to resolve rider's barn
- Add cross-barn isolation tests (list, lookup, mutation isolation)
- Fix E2E test ordering so smoke tests run before regression (prevents stale auth from resetDatabase)
- Include Barn table in resetDatabase TRUNCATE for barn-scoped seed

## Test plan

- [x] `pnpm run check` passes (format + typecheck)
- [x] All API tests pass (`pnpm vitest run` — 58 passed)
- [x] New `barnIsolation.access.test.ts` covers 10 cross-barn scenarios
- [x] E2E full suite passes (28/28 — smoke + regression, Chrome + Safari)

🤖 Generated with [Claude Code](https://claude.com/claude-code)