### PR TITLE
feat(api): add barn query and management mutations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Example:
 - Throw `GraphQLError` with codes (`NOT_FOUND`, `UNAUTHENTICATED`) - don't return null
 - Update `schema.graphql` when `schema.prisma` changes
 - Watch for N+1 queries in nested resolvers
+- Do not add inline `if (!context.rider)` checks in resolver bodies — `secureByDefaultTransformer` rejects unauthenticated requests for all non-`@public` fields before resolvers run. Use shared helpers (`getBarnId`, `requireTrainer`, `requireOwnerOrTrainer`) which keep their null checks for TypeScript type narrowing. Only add role-based guards where needed.
 
 ## Frontend (packages/web)
 

--- a/packages/api/src/graphql/schema.graphql
+++ b/packages/api/src/graphql/schema.graphql
@@ -11,6 +11,7 @@ type Barn {
     id: ID!
     name: String!
     inviteCode: String
+    riders: [Rider!]!
     createdAt: DateTime!
 }
 
@@ -85,6 +86,7 @@ type AuthPayload {
 }
 
 type Query {
+    barn: Barn!
     horses: [Horse!]!
     riders: [Rider!]!
     sessions(
@@ -126,6 +128,8 @@ type Mutation {
         notes: String
     ): Session!
     deleteSession(id: ID!): Boolean!
+    updateBarn(name: String!): Barn!
+    regenerateInviteCode: Barn!
     login(email: String!, password: String!): AuthPayload! @public
     signup(name: String!, email: String!, password: String!, inviteCode: String!): AuthPayload!
         @public

--- a/packages/api/src/test/access/barn.access.test.ts
+++ b/packages/api/src/test/access/barn.access.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { prisma } from '@/db';
+import type { World } from '@/test/setupWorld';
+import { setupWorld } from '@/test/setupWorld';
+import { GET_BARN, UPDATE_BARN, REGENERATE_INVITE_CODE } from '@/test/queries';
+
+describe('barn query', () => {
+    let world: World;
+
+    beforeAll(async () => {
+        world = await setupWorld('barnQuery');
+        // Promote userA to trainer for inviteCode visibility tests
+        await prisma.rider.update({
+            where: { id: world.userA.riderId },
+            data: { role: 'TRAINER' },
+        });
+    });
+
+    afterAll(async () => {
+        await world.teardown();
+    });
+
+    it('rejects unauthenticated requests', async () => {
+        const res = await world.asAnon.gql(GET_BARN);
+
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+    });
+
+    it('returns barn data for authenticated rider', async () => {
+        const res = await world.userB.gql<{
+            barn: { id: string; name: string; createdAt: string };
+        }>(GET_BARN);
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.barn.id).toBeTruthy();
+        expect(res.data!.barn.name).toContain('barnQuery');
+    });
+
+    it('returns riders list', async () => {
+        const res = await world.userB.gql<{
+            barn: { riders: Array<{ id: string; name: string }> };
+        }>(GET_BARN);
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.barn.riders.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('hides inviteCode from riders', async () => {
+        const res = await world.userB.gql<{
+            barn: { inviteCode: string | null };
+        }>(GET_BARN);
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.barn.inviteCode).toBeNull();
+    });
+
+    it('shows inviteCode to trainers', async () => {
+        const res = await world.userA.gql<{
+            barn: { inviteCode: string | null };
+        }>(GET_BARN);
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.barn.inviteCode).toBeTruthy();
+    });
+});
+
+describe('updateBarn', () => {
+    let world: World;
+
+    beforeAll(async () => {
+        world = await setupWorld('updateBarn');
+        // Promote userA to trainer
+        await prisma.rider.update({
+            where: { id: world.userA.riderId },
+            data: { role: 'TRAINER' },
+        });
+    });
+
+    afterAll(async () => {
+        await world.teardown();
+    });
+
+    it('rejects unauthenticated requests', async () => {
+        const res = await world.asAnon.gql(UPDATE_BARN, {
+            name: 'New Name',
+        });
+
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+    });
+
+    it('rejects rider role', async () => {
+        const res = await world.userB.gql(UPDATE_BARN, {
+            name: 'Rider Rename',
+        });
+
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('FORBIDDEN');
+    });
+
+    it('allows trainer to rename', async () => {
+        const res = await world.userA.gql<{
+            updateBarn: { id: string; name: string };
+        }>(UPDATE_BARN, { name: 'Renamed Barn' });
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.updateBarn.name).toBe('Renamed Barn');
+    });
+
+    it('trims whitespace from name', async () => {
+        const res = await world.userA.gql<{
+            updateBarn: { name: string };
+        }>(UPDATE_BARN, { name: '  Trimmed Barn  ' });
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.updateBarn.name).toBe('Trimmed Barn');
+    });
+
+    it('rejects empty/whitespace name', async () => {
+        const res = await world.userA.gql(UPDATE_BARN, { name: '   ' });
+
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('BAD_USER_INPUT');
+    });
+
+    it('rejects name exceeding 100 characters', async () => {
+        const res = await world.userA.gql(UPDATE_BARN, {
+            name: 'A'.repeat(101),
+        });
+
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('BAD_USER_INPUT');
+    });
+});
+
+describe('regenerateInviteCode', () => {
+    let world: World;
+
+    beforeAll(async () => {
+        world = await setupWorld('regenCode');
+        // Promote userA to trainer
+        await prisma.rider.update({
+            where: { id: world.userA.riderId },
+            data: { role: 'TRAINER' },
+        });
+    });
+
+    afterAll(async () => {
+        await world.teardown();
+    });
+
+    it('rejects unauthenticated requests', async () => {
+        const res = await world.asAnon.gql(REGENERATE_INVITE_CODE);
+
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+    });
+
+    it('rejects rider role', async () => {
+        const res = await world.userB.gql(REGENERATE_INVITE_CODE);
+
+        expect(res.errors).toBeDefined();
+        expect(res.errors![0].extensions?.code).toBe('FORBIDDEN');
+    });
+
+    it('returns new code for trainer', async () => {
+        const res = await world.userA.gql<{
+            regenerateInviteCode: { id: string; inviteCode: string };
+        }>(REGENERATE_INVITE_CODE);
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data!.regenerateInviteCode.inviteCode).toBeTruthy();
+        expect(res.data!.regenerateInviteCode.inviteCode).toHaveLength(8);
+    });
+
+    it('new code differs from old code', async () => {
+        const first = await world.userA.gql<{
+            regenerateInviteCode: { inviteCode: string };
+        }>(REGENERATE_INVITE_CODE);
+
+        const second = await world.userA.gql<{
+            regenerateInviteCode: { inviteCode: string };
+        }>(REGENERATE_INVITE_CODE);
+
+        expect(first.data!.regenerateInviteCode.inviteCode).not.toBe(
+            second.data!.regenerateInviteCode.inviteCode
+        );
+    });
+});

--- a/packages/api/src/test/queries.ts
+++ b/packages/api/src/test/queries.ts
@@ -99,7 +99,40 @@ export const DELETE_SESSION = /* GraphQL */ `
     }
 `;
 
+export const UPDATE_BARN = /* GraphQL */ `
+    mutation UpdateBarn($name: String!) {
+        updateBarn(name: $name) {
+            id
+            name
+        }
+    }
+`;
+
+export const REGENERATE_INVITE_CODE = /* GraphQL */ `
+    mutation RegenerateInviteCode {
+        regenerateInviteCode {
+            id
+            inviteCode
+        }
+    }
+`;
+
 // ── Queries ──────────────────────────────────────────────────────────
+
+export const GET_BARN = /* GraphQL */ `
+    query Barn {
+        barn {
+            id
+            name
+            inviteCode
+            riders {
+                id
+                name
+            }
+            createdAt
+        }
+    }
+`;
 
 export const GET_HORSES = /* GraphQL */ `
     query Horses {

--- a/packages/web/src/generated/graphql.ts
+++ b/packages/web/src/generated/graphql.ts
@@ -42,6 +42,7 @@ export type Barn = {
     id: Scalars['ID']['output'];
     inviteCode: Maybe<Scalars['String']['output']>;
     name: Scalars['String']['output'];
+    riders: Array<Rider>;
 };
 
 export type Horse = {
@@ -83,7 +84,9 @@ export type Mutation = {
     createSession: Session;
     deleteSession: Scalars['Boolean']['output'];
     login: AuthPayload;
+    regenerateInviteCode: Barn;
     signup: AuthPayload;
+    updateBarn: Barn;
     updateHorse: Horse;
     updateSession: Session;
 };
@@ -120,6 +123,10 @@ export type MutationSignupArgs = {
     password: Scalars['String']['input'];
 };
 
+export type MutationUpdateBarnArgs = {
+    name: Scalars['String']['input'];
+};
+
 export type MutationUpdateHorseArgs = {
     id: Scalars['ID']['input'];
     isActive: InputMaybe<Scalars['Boolean']['input']>;
@@ -141,6 +148,7 @@ export type MutationUpdateSessionArgs = {
 
 export type Query = {
     __typename?: 'Query';
+    barn: Barn;
     horse: Maybe<Horse>;
     horses: Array<Horse>;
     lastSessionForHorse: Maybe<Session>;


### PR DESCRIPTION
## Summary

Closes #87

- Add `Query.barn` — returns the current rider's barn with riders list
- Add `Mutation.updateBarn(name)` — trainer-only rename with trim + empty validation
- Add `Mutation.regenerateInviteCode` — trainer-only, generates new 8-char code
- Add `Barn.riders` field resolver (password omitted)
- Remove redundant inline `if (!context.rider)` checks from session resolvers (secureByDefaultTransformer already handles authentication)
- Rename `requireAuth` → `getBarnId` to clarify the helper extracts barn-scoping data, not auth
- Catch P2002 on signup for clean `EMAIL_IN_USE` error on concurrent duplicate emails
- Document auth pattern convention in CLAUDE.md

## Test plan

- [x] 13 new access-gating tests across barn query, updateBarn, and regenerateInviteCode
- [x] All 95 API tests pass
- [x] Typecheck and format clean
- [x] Manual test via dev server: query barn, updateBarn, regenerateInviteCode