### PR TITLE
Add barn section to profile page

### DIFF
--- a/packages/web/src/components/BarnNameEditSheet.tsx
+++ b/packages/web/src/components/BarnNameEditSheet.tsx
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react';
+
+import {
+    Sheet,
+    SheetContent,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface BarnNameEditSheetProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    currentName: string;
+    onSave: (name: string) => void;
+    saving: boolean;
+}
+
+export default function BarnNameEditSheet({
+    open,
+    onOpenChange,
+    currentName,
+    onSave,
+    saving,
+}: BarnNameEditSheetProps): React.ReactNode {
+    const [name, setName] = useState(currentName);
+
+    useEffect(() => {
+        setName(currentName);
+    }, [currentName, open]);
+
+    const trimmed = name.trim();
+    const canSave = trimmed.length > 0 && trimmed.length <= 100 && !saving;
+
+    const handleSave = (): void => {
+        if (canSave) {
+            onSave(trimmed);
+        }
+    };
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent side="bottom" className="[&>button]:hidden">
+                <SheetHeader>
+                    <SheetTitle>Rename Barn</SheetTitle>
+                </SheetHeader>
+                <div className="space-y-4 pt-4">
+                    <Input
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        maxLength={100}
+                        autoFocus
+                        placeholder="Barn name"
+                    />
+                    <Button
+                        className="w-full"
+                        disabled={!canSave}
+                        onClick={handleSave}
+                    >
+                        {saving ? 'Saving...' : 'Save'}
+                    </Button>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/packages/web/src/components/BarnSection.tsx
+++ b/packages/web/src/components/BarnSection.tsx
@@ -1,0 +1,260 @@
+import { useState } from 'react';
+import { gql } from '@apollo/client';
+import { useQuery, useMutation } from '@apollo/client/react';
+import { Copy, Check, ArrowUpFromLine, RefreshCw } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import SummaryRow from '@/components/session/SummaryRow';
+import BarnNameEditSheet from '@/components/BarnNameEditSheet';
+import { useAuth } from '@/context/AuthContext';
+import type {
+    GetBarnQuery,
+    UpdateBarnMutation,
+    UpdateBarnMutationVariables,
+    RegenerateInviteCodeMutation,
+} from '@/generated/graphql';
+
+const GET_BARN = gql`
+    query GetBarn {
+        barn {
+            id
+            name
+            inviteCode
+            riders {
+                id
+            }
+        }
+    }
+`;
+
+const UPDATE_BARN = gql`
+    mutation UpdateBarn($name: String!) {
+        updateBarn(name: $name) {
+            id
+            name
+        }
+    }
+`;
+
+const REGENERATE_INVITE_CODE = gql`
+    mutation RegenerateInviteCode {
+        regenerateInviteCode {
+            id
+            inviteCode
+        }
+    }
+`;
+
+export default function BarnSection(): React.ReactNode {
+    const { isTrainer } = useAuth();
+    const [editOpen, setEditOpen] = useState(false);
+    const [copied, setCopied] = useState(false);
+
+    const { data, loading, error } = useQuery<GetBarnQuery>(GET_BARN);
+
+    const [updateBarn, { loading: updating }] = useMutation<
+        UpdateBarnMutation,
+        UpdateBarnMutationVariables
+    >(UPDATE_BARN);
+
+    const [regenerateInviteCode, { loading: regenerating }] =
+        useMutation<RegenerateInviteCodeMutation>(REGENERATE_INVITE_CODE);
+
+    const handleSaveName = async (name: string): Promise<void> => {
+        await updateBarn({
+            variables: { name },
+            update(cache) {
+                cache.evict({ fieldName: 'barn' });
+                cache.gc();
+            },
+        });
+        setEditOpen(false);
+    };
+
+    const handleRegenerate = async (): Promise<void> => {
+        await regenerateInviteCode({
+            update(cache) {
+                cache.evict({ fieldName: 'barn' });
+                cache.gc();
+            },
+        });
+    };
+
+    const handleCopy = async (code: string): Promise<void> => {
+        await navigator.clipboard.writeText(code);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const handleShare = async (code: string): Promise<void> => {
+        const shareData = {
+            title: 'Join my barn',
+            text: `Use this invite code to join my barn: ${code}`,
+        };
+
+        if (navigator.share) {
+            await navigator.share(shareData);
+        } else {
+            await handleCopy(code);
+        }
+    };
+
+    if (loading) {
+        return (
+            <section>
+                <h2 className="text-sm font-medium text-muted-foreground mb-2 px-1">
+                    Barn
+                </h2>
+                <div className="space-y-3">
+                    <Skeleton className="h-10 w-full rounded-lg" />
+                    <Skeleton className="h-10 w-full rounded-lg" />
+                </div>
+            </section>
+        );
+    }
+
+    if (error || !data) {
+        return (
+            <section>
+                <h2 className="text-sm font-medium text-muted-foreground mb-2 px-1">
+                    Barn
+                </h2>
+                <p className="text-sm text-muted-foreground">
+                    Unable to load barn information
+                </p>
+            </section>
+        );
+    }
+
+    const barn = data.barn;
+    const memberCount = barn.riders.length;
+
+    if (isTrainer) {
+        return (
+            <section>
+                <h2 className="text-sm font-medium text-muted-foreground mb-2 px-1">
+                    Barn
+                </h2>
+
+                <SummaryRow
+                    label="Name"
+                    value={barn.name}
+                    onClick={() => setEditOpen(true)}
+                />
+
+                <div className="flex items-center justify-between py-3 px-1 border-b border-border min-h-[52px]">
+                    <span className="text-base text-muted-foreground">
+                        Members
+                    </span>
+                    <span className="text-base text-foreground">
+                        {memberCount}
+                    </span>
+                </div>
+
+                {barn.inviteCode && (
+                    <div className="mt-3 space-y-2">
+                        <div className="flex items-center gap-2">
+                            <code className="flex-1 rounded-lg bg-muted/50 px-3 py-2 font-mono text-base">
+                                {barn.inviteCode}
+                            </code>
+                            <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={() => handleCopy(barn.inviteCode!)}
+                                aria-label="Copy invite code"
+                            >
+                                {copied ? (
+                                    <Check className="h-4 w-4" />
+                                ) : (
+                                    <Copy className="h-4 w-4" />
+                                )}
+                            </Button>
+                            <Button
+                                variant="outline"
+                                size="icon"
+                                onClick={() => handleShare(barn.inviteCode!)}
+                                aria-label="Share invite code"
+                            >
+                                <ArrowUpFromLine className="h-4 w-4" />
+                            </Button>
+                        </div>
+
+                        <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                                <Button
+                                    variant="ghost"
+                                    className="w-full"
+                                    disabled={regenerating}
+                                >
+                                    <RefreshCw
+                                        className={`mr-2 h-4 w-4 ${regenerating ? 'animate-spin' : ''}`}
+                                    />
+                                    Regenerate Invite Code
+                                </Button>
+                            </AlertDialogTrigger>
+                            <AlertDialogContent>
+                                <AlertDialogHeader>
+                                    <AlertDialogTitle>
+                                        Regenerate invite code?
+                                    </AlertDialogTitle>
+                                    <AlertDialogDescription>
+                                        The current invite code will stop
+                                        working. Anyone who hasn&apos;t signed
+                                        up yet will need the new code.
+                                    </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                    <AlertDialogCancel>
+                                        Cancel
+                                    </AlertDialogCancel>
+                                    <AlertDialogAction
+                                        onClick={handleRegenerate}
+                                    >
+                                        Regenerate
+                                    </AlertDialogAction>
+                                </AlertDialogFooter>
+                            </AlertDialogContent>
+                        </AlertDialog>
+                    </div>
+                )}
+
+                <BarnNameEditSheet
+                    open={editOpen}
+                    onOpenChange={setEditOpen}
+                    currentName={barn.name}
+                    onSave={handleSaveName}
+                    saving={updating}
+                />
+            </section>
+        );
+    }
+
+    // Rider view — read-only
+    return (
+        <section>
+            <h2 className="text-sm font-medium text-muted-foreground mb-2 px-1">
+                Barn
+            </h2>
+            <div className="flex items-center justify-between py-3 px-1 border-b border-border min-h-[52px]">
+                <span className="text-base text-muted-foreground">Name</span>
+                <span className="text-base text-foreground">{barn.name}</span>
+            </div>
+            <div className="flex items-center justify-between py-3 px-1 border-b border-border min-h-[52px]">
+                <span className="text-base text-muted-foreground">Members</span>
+                <span className="text-base text-foreground">{memberCount}</span>
+            </div>
+        </section>
+    );
+}

--- a/packages/web/src/generated/graphql.ts
+++ b/packages/web/src/generated/graphql.ts
@@ -225,6 +225,41 @@ export enum WorkType {
     Trail = 'TRAIL',
 }
 
+export type GetBarnQueryVariables = Exact<{ [key: string]: never }>;
+
+export type GetBarnQuery = {
+    __typename?: 'Query';
+    barn: {
+        __typename?: 'Barn';
+        id: string;
+        name: string;
+        inviteCode: string | null;
+        riders: Array<{ __typename?: 'Rider'; id: string }>;
+    };
+};
+
+export type UpdateBarnMutationVariables = Exact<{
+    name: Scalars['String']['input'];
+}>;
+
+export type UpdateBarnMutation = {
+    __typename?: 'Mutation';
+    updateBarn: { __typename?: 'Barn'; id: string; name: string };
+};
+
+export type RegenerateInviteCodeMutationVariables = Exact<{
+    [key: string]: never;
+}>;
+
+export type RegenerateInviteCodeMutation = {
+    __typename?: 'Mutation';
+    regenerateInviteCode: {
+        __typename?: 'Barn';
+        id: string;
+        inviteCode: string | null;
+    };
+};
+
 export type GetDashboardDataQueryVariables = Exact<{ [key: string]: never }>;
 
 export type GetDashboardDataQuery = {

--- a/packages/web/src/pages/Profile.tsx
+++ b/packages/web/src/pages/Profile.tsx
@@ -1,7 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/context/AuthContext';
 import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
 import { LogOut } from 'lucide-react';
+import BarnSection from '@/components/BarnSection';
 
 export default function Profile() {
     const { riderName, logout } = useAuth();
@@ -25,9 +27,15 @@ export default function Profile() {
                 </div>
             </div>
 
+            <Separator />
+
+            <BarnSection />
+
+            <Separator />
+
             <Button
-                variant="destructive"
-                className="w-full"
+                variant="ghost"
+                className="w-full text-muted-foreground"
                 onClick={handleLogout}
             >
                 <LogOut className="h-4 w-4 mr-2" />


### PR DESCRIPTION
## Summary
- Riders see barn name and member count on the Me/Profile page
- Trainers get invite code display with copy/share, inline barn rename, and invite code regeneration with confirmation
- Subtler ghost-style logout button

Closes #88

## Test plan
- [x] Log in as rider — see barn name and member count, no management controls
- [x] Log in as trainer — see tappable barn name, member count, invite code with copy/share, regenerate button
- [x] Trainer: rename barn via bottom sheet
- [x] Trainer: copy invite code (checkmark feedback)
- [x] Trainer: share invite code (native share or clipboard fallback)
- [x] Trainer: regenerate invite code with confirmation dialog
- [x] Loading skeleton renders on first load
- [x] `pnpm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)