### PR TITLE
chore(web): add Sentry performance tracing

### DIFF
--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -14,6 +14,9 @@ VITE_DEV_AUTOLOGIN=true
 # Sentry error tracking (optional — omit to disable)
 # VITE_SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 
+# Sentry performance tracing sample rate (0–1, default 0 = disabled)
+# VITE_SENTRY_TRACES_SAMPLE_RATE=0.2
+
 # Build-time only (CI): upload source maps to Sentry
 # SENTRY_AUTH_TOKEN=sntrys_...  (or SENTRY_TOKEN as fallback)
 # SENTRY_ORG=your-org

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
     Route,
     Navigate,
 } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 
 import { useAuth } from '@/context/AuthContext';
 
@@ -22,6 +23,8 @@ import VoiceSessionCapture from '@/pages/VoiceSessionCapture';
 import TabLayout from '@/layouts/TabLayout';
 import FullScreenLayout from '@/layouts/FullScreenLayout';
 
+const SentryRoutes = Sentry.withSentryReactRouterV7Routing(Routes);
+
 const PublicRoute: React.FC<{ element: React.ReactElement }> = ({
     element,
 }) => {
@@ -31,7 +34,7 @@ const PublicRoute: React.FC<{ element: React.ReactElement }> = ({
 
 function AppRoutes(): React.ReactNode {
     return (
-        <Routes>
+        <SentryRoutes>
             <Route
                 path="/login"
                 element={<PublicRoute element={<Login />} />}
@@ -61,7 +64,7 @@ function AppRoutes(): React.ReactNode {
             </Route>
 
             <Route path="*" element={<Navigate to="/" />} />
-        </Routes>
+        </SentryRoutes>
     );
 }
 

--- a/packages/web/src/lib/apollo.ts
+++ b/packages/web/src/lib/apollo.ts
@@ -3,18 +3,21 @@ import { SetContextLink } from '@apollo/client/link/context';
 import { ErrorLink } from '@apollo/client/link/error';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { GRAPHQL_URL } from './api';
-import { captureGraphQLError } from './sentry';
+import { captureGraphQLError, GRAPHQL_OP_HEADER } from './sentry';
 
 const httpLink = new HttpLink({
     uri: GRAPHQL_URL,
 });
 
-const authLink = new SetContextLink(({ headers }, _) => {
+const authLink = new SetContextLink(({ headers }, request) => {
     const token = localStorage.getItem('token');
     return {
         headers: {
             ...headers,
             authorization: token ? `Bearer ${token}` : '',
+            ...(request.operationName && {
+                [GRAPHQL_OP_HEADER]: request.operationName,
+            }),
         },
     };
 });

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -8,6 +8,8 @@ interface ImportMetaEnv {
     readonly VITE_DEV_AUTOLOGIN?: string;
     /** Sentry DSN for error tracking. Omit to disable Sentry. */
     readonly VITE_SENTRY_DSN?: string;
+    /** Sentry performance traces sample rate (0–1). Defaults to 0 (disabled). */
+    readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Configure `reactRouterV7BrowserTracingIntegration` for parameterized route transaction names (`/horses/:id` not `/horses/abc123`)
- Parse `VITE_SENTRY_TRACES_SAMPLE_RATE` env var (default `0`) to control trace sampling
- Scope `tracePropagationTargets` to API endpoints only (`/graphql`, `/api/`, `VITE_API_URL`)
- Enrich GraphQL fetch spans with operation names via `x-graphql-operation-name` header and `onRequestSpanStart` callback
- Wrap `<Routes>` with `SentryRoutes` HOC in `App.tsx`

Closes #64

## Test plan
- [x] Set `VITE_SENTRY_TRACES_SAMPLE_RATE=1.0` and `VITE_SENTRY_DSN` in `.env.local`, start dev server, navigate between pages — verify Sentry dashboard shows transactions with parameterized route names
- [x] Check browser DevTools Network tab for `sentry-trace` and `baggage` headers on `/graphql` requests
- [x] Verify GraphQL spans show operation names (e.g., `POST /graphql (GetHorses)`)
- [x] Remove `VITE_SENTRY_DSN` — confirm app works normally with no errors
- [x] `pnpm run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)