### PR TITLE
feat(web): add invite code validation and E2E signup test

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -10,7 +10,11 @@
     },
     "devDependencies": {
         "@playwright/test": "^1.57.0",
+        "@prisma/adapter-pg": "^7.1.0",
+        "@prisma/client": "^7.1.0",
         "@types/node": "^24.10.2",
+        "@types/pg": "^8.15.6",
+        "pg": "^8.16.3",
         "typescript": "^5.9.3"
     }
 }

--- a/packages/e2e/tests/regression/horses.spec.ts
+++ b/packages/e2e/tests/regression/horses.spec.ts
@@ -2,8 +2,8 @@ import { test, expect } from '@playwright/test';
 import { TEST_RIDER_EMAIL, TEST_RIDER_PASSWORD } from '@/seedConstants';
 import { resetDatabase } from '../utils/resetDatabase';
 
-test.beforeAll(() => {
-    resetDatabase();
+test.beforeAll(async () => {
+    await resetDatabase();
 });
 
 test.describe('Horse Management', () => {

--- a/packages/e2e/tests/regression/sessions.spec.ts
+++ b/packages/e2e/tests/regression/sessions.spec.ts
@@ -7,8 +7,8 @@ import {
 } from '@/seedConstants';
 import { resetDatabase } from '../utils/resetDatabase';
 
-test.beforeAll(() => {
-    resetDatabase();
+test.beforeAll(async () => {
+    await resetDatabase();
 });
 
 /** Helper: open the field edit drawer, select an option, and wait for it to close */

--- a/packages/e2e/tests/seedConstants.ts
+++ b/packages/e2e/tests/seedConstants.ts
@@ -4,3 +4,4 @@ export const TEST_RIDER_NAME = 'Test Rider';
 export const TEST_HORSE_NAME = 'Test Horse';
 export const TEST_SESSION_NOTE = 'Seed session for E2E tests';
 export const TEST_BARN_NAME = 'Test Barn';
+export const TEST_SIGNUP_INVITE_CODE = 'E2ETEST01';

--- a/packages/e2e/tests/utils/db.ts
+++ b/packages/e2e/tests/utils/db.ts
@@ -1,0 +1,28 @@
+import { PrismaClient } from '@prisma/client';
+import { PrismaPg } from '@prisma/adapter-pg';
+import pg from 'pg';
+
+const DATABASE_URL = 'postgresql://postgres:test@127.0.0.1:5433/herdbook_test';
+
+let prisma: PrismaClient | null = null;
+let pool: pg.Pool | null = null;
+
+export function getTestPrisma(): PrismaClient {
+    if (!prisma) {
+        pool = new pg.Pool({ connectionString: DATABASE_URL });
+        const adapter = new PrismaPg(pool);
+        prisma = new PrismaClient({ adapter });
+    }
+    return prisma;
+}
+
+export async function disconnectTestPrisma(): Promise<void> {
+    if (prisma) {
+        await prisma.$disconnect();
+        prisma = null;
+    }
+    if (pool) {
+        await pool.end();
+        pool = null;
+    }
+}

--- a/packages/e2e/tests/utils/resetDatabase.ts
+++ b/packages/e2e/tests/utils/resetDatabase.ts
@@ -1,17 +1,20 @@
 import { execSync } from 'child_process';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { getTestPrisma } from './db';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT_DIR = resolve(__dirname, '../../../..');
 const DATABASE_URL = 'postgresql://postgres:test@127.0.0.1:5433/herdbook_test';
 
-export function resetDatabase(): void {
-    execSync(
-        `psql "${DATABASE_URL}" -c 'TRUNCATE TABLE "Session", "Horse", "Rider", "Barn" CASCADE'`,
-        { stdio: 'pipe' }
-    );
+export async function resetDatabase(): Promise<void> {
+    const prisma = getTestPrisma();
+    await prisma.session.deleteMany();
+    await prisma.horse.deleteMany();
+    await prisma.rider.deleteMany();
+    await prisma.barn.deleteMany();
+
     execSync('pnpm --filter api prisma:seed:e2e', {
         stdio: 'pipe',
         cwd: ROOT_DIR,

--- a/packages/e2e/tests/utils/testBarn.ts
+++ b/packages/e2e/tests/utils/testBarn.ts
@@ -1,0 +1,32 @@
+import { getTestPrisma } from './db';
+
+interface TestBarn {
+    barnId: string;
+    cleanup: () => Promise<void>;
+}
+
+export async function createTestBarn(inviteCode: string): Promise<TestBarn> {
+    const prisma = getTestPrisma();
+
+    const barn = await prisma.barn.create({
+        data: { name: 'Signup Test Barn', inviteCode },
+    });
+
+    return {
+        barnId: barn.id,
+        cleanup: async () => {
+            const riders = await prisma.rider.findMany({
+                where: { barnId: barn.id },
+                select: { id: true },
+            });
+            if (riders.length > 0) {
+                await prisma.session.deleteMany({
+                    where: { riderId: { in: riders.map((r) => r.id) } },
+                });
+            }
+            await prisma.horse.deleteMany({ where: { barnId: barn.id } });
+            await prisma.rider.deleteMany({ where: { barnId: barn.id } });
+            await prisma.barn.delete({ where: { id: barn.id } });
+        },
+    };
+}

--- a/packages/web/src/pages/Signup.tsx
+++ b/packages/web/src/pages/Signup.tsx
@@ -79,6 +79,7 @@ export default function Signup() {
                             <Input
                                 id="name"
                                 type="text"
+                                required
                                 value={name}
                                 onChange={(e) => setName(e.target.value)}
                             />
@@ -88,6 +89,7 @@ export default function Signup() {
                             <Input
                                 id="email"
                                 type="email"
+                                required
                                 value={email}
                                 onChange={(e) => setEmail(e.target.value)}
                             />
@@ -97,6 +99,7 @@ export default function Signup() {
                             <Input
                                 id="password"
                                 type="password"
+                                required
                                 value={password}
                                 onChange={(e) => setPassword(e.target.value)}
                             />
@@ -106,6 +109,7 @@ export default function Signup() {
                             <Input
                                 id="inviteCode"
                                 type="text"
+                                required
                                 value={inviteCode}
                                 onChange={(e) => setInviteCode(e.target.value)}
                             />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,9 +114,21 @@ importers:
       '@playwright/test':
         specifier: ^1.57.0
         version: 1.57.0
+      '@prisma/adapter-pg':
+        specifier: ^7.1.0
+        version: 7.1.0
+      '@prisma/client':
+        specifier: ^7.1.0
+        version: 7.1.0(prisma@7.1.0(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3))(typescript@5.9.3)
       '@types/node':
         specifier: ^24.10.2
         version: 24.10.2
+      '@types/pg':
+        specifier: ^8.15.6
+        version: 8.15.6
+      pg:
+        specifier: ^8.16.3
+        version: 8.16.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## Summary
- Add `required` attribute to all signup form inputs so empty submissions are blocked by browser validation
- Create `testBarn` E2E helper for isolated barn creation/cleanup via psql
- Un-skip signup smoke test with invite code field support and per-test barn lifecycle

Closes #89

## Test plan
- [x] Open signup page, try submitting with empty fields — browser blocks submission
- [x] Fill all fields with invalid invite code — see "Invalid invite code" error
- [x] Run E2E smoke tests: `pnpm run --filter e2e test -- tests/smoke/auth.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)