### PR TITLE
fix(web): refresh stale session data across users

### DIFF
--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -40,9 +40,12 @@ export default function Dashboard(): React.ReactNode {
     const { data, loading, error } = useQuery<
         GetDashboardDataQuery,
         GetDashboardDataQueryVariables
-    >(DASHBOARD_QUERY);
+    >(DASHBOARD_QUERY, {
+        fetchPolicy: 'cache-and-network',
+        nextFetchPolicy: 'cache-first',
+    });
 
-    if (loading)
+    if (loading && !data)
         return <div className="p-4 text-center">Loading activity...</div>;
     if (error)
         return (

--- a/packages/web/src/pages/HorseProfile.tsx
+++ b/packages/web/src/pages/HorseProfile.tsx
@@ -64,7 +64,11 @@ export default function HorseProfile(): React.ReactNode {
     const { data, loading, refetch } = useQuery<
         GetHorseProfileQuery,
         GetHorseProfileQueryVariables
-    >(GET_HORSE_PROFILE, { variables: { id: id! } });
+    >(GET_HORSE_PROFILE, {
+        variables: { id: id! },
+        fetchPolicy: 'cache-and-network',
+        nextFetchPolicy: 'cache-first',
+    });
 
     if (loading && !data) {
         return (

--- a/packages/web/src/pages/Sessions.tsx
+++ b/packages/web/src/pages/Sessions.tsx
@@ -143,6 +143,8 @@ export default function Sessions(): React.ReactNode {
                 offset: 0,
                 ...filters.queryVariables,
             },
+            fetchPolicy: 'cache-and-network',
+            nextFetchPolicy: 'cache-first',
         }
     );
 
@@ -211,7 +213,7 @@ export default function Sessions(): React.ReactNode {
                 />
             </div>
 
-            {loading ? (
+            {loading && !data ? (
                 <div className="space-y-3">
                     <SessionSkeleton />
                     <SessionSkeleton />


### PR DESCRIPTION
## Summary
- Set `fetchPolicy: 'cache-and-network'` + `nextFetchPolicy: 'cache-first'` on `GetDashboardData`, `GetSessions`, and `GetHorseProfile` queries
- Cached data renders instantly on navigation; a background network request silently refreshes it so riders see each other's logged sessions without a full browser refresh
- Loading guards updated to `loading && !data` to prevent skeleton flash during background refetch

## Test plan
- [ ] Open app in two browser tabs as two different riders
- [ ] Rider A logs a session
- [ ] Rider B navigates to Dashboard — new session appears without refresh
- [ ] Rider B navigates to Sessions — new session appears in list
- [ ] Rider B navigates to Horse Profile — session and activity reflect the new session
- [ ] Confirm no loading spinner flash on navigation when cached data exists
- [ ] Confirm "Load more" pagination still works on Sessions page

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)