### PR TITLE
fix(web): add error handling to unguarded async handlers

### DIFF
--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -91,9 +91,10 @@ Apply feedback, re-format, and ask the user to verify again. Repeat until they'r
 Once the user approves:
 
 1. Run `/preflight` to check formatting + types
-2. Ask the user for final go-ahead to commit
-3. Run `/commit` to create the commit
-4. Ask if the user wants to push and create a PR
+2. Run `/pre-review` for independent code review
+3. Ask the user for final go-ahead to commit
+4. Run `/commit` to create the commit
+5. Ask if the user wants to push and create a PR
 
 ## Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Leave the codebase slightly better than you found it. When a change reveals near
 - Local state preferred (`useState`/`useReducer`)
 - Touch targets: minimum 44x44px
 - **Navigation & layouts**: see [docs/design-navigation.md](docs/design-navigation.md) for layout types, sub-page overlay system, view/edit cascade, drawer-based editing, animation standards, and the new page checklist
+- **Error handling**: `useState<string | null>(null)` for `formError`, try/catch with `setFormError(err instanceof Error ? err.message : 'An error occurred')`, display with `<p className="text-sm text-red-500">`. Browser APIs (clipboard, share) silently degrade — no error display
 
 ## Security
 

--- a/packages/web/src/components/BarnNameEditSheet.tsx
+++ b/packages/web/src/components/BarnNameEditSheet.tsx
@@ -15,6 +15,7 @@ interface BarnNameEditSheetProps {
     currentName: string;
     onSave: (name: string) => void;
     saving: boolean;
+    error?: string | null;
 }
 
 export default function BarnNameEditSheet({
@@ -23,6 +24,7 @@ export default function BarnNameEditSheet({
     currentName,
     onSave,
     saving,
+    error,
 }: BarnNameEditSheetProps): React.ReactNode {
     const [name, setName] = useState(currentName);
 
@@ -53,6 +55,7 @@ export default function BarnNameEditSheet({
                         autoFocus
                         placeholder="Barn name"
                     />
+                    {error && <p className="text-sm text-red-500">{error}</p>}
                     <Button
                         className="w-full"
                         disabled={!canSave}

--- a/packages/web/src/components/session/SessionEditor.tsx
+++ b/packages/web/src/components/session/SessionEditor.tsx
@@ -52,6 +52,7 @@ interface SessionEditorProps {
     saving: boolean;
     showRiderPicker?: boolean;
     extraActions?: React.ReactNode;
+    error?: string | null;
 }
 
 export default function SessionEditor({
@@ -64,6 +65,7 @@ export default function SessionEditor({
     saving,
     showRiderPicker = true,
     extraActions,
+    error,
 }: SessionEditorProps): React.ReactNode {
     const [values, setValues] = useState<SessionValues>(initialValues);
     const [sheetOpen, setSheetOpen] = useState(false);
@@ -238,6 +240,9 @@ export default function SessionEditor({
                             <p className="text-sm text-red-500 mt-4">
                                 {formError}
                             </p>
+                        )}
+                        {error && (
+                            <p className="text-sm text-red-500 mt-4">{error}</p>
                         )}
 
                         <div className="mt-6 space-y-3">

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -5,6 +5,16 @@ export function cn(...inputs: ClassValue[]): string {
     return twMerge(clsx(inputs));
 }
 
+export function getUserErrorMessage(err: unknown): string {
+    if (err instanceof Error) {
+        if (err.message === 'Failed to fetch') {
+            return 'Network error — check your connection and try again';
+        }
+        return err.message;
+    }
+    return 'An error occurred';
+}
+
 export function formatTimeAgo(date: Date): string {
     const now = new Date();
     const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);

--- a/packages/web/src/pages/SessionDetail.tsx
+++ b/packages/web/src/pages/SessionDetail.tsx
@@ -31,7 +31,7 @@ import SessionEditor from '@/components/session/SessionEditor';
 import type { SessionValues } from '@/components/session/SessionEditor';
 import { useAppNavigate } from '@/hooks/useAppNavigate';
 import { useAuth } from '@/context/AuthContext';
-import { cn } from '@/lib/utils';
+import { cn, getUserErrorMessage } from '@/lib/utils';
 import {
     parseSessionDate,
     formatSessionTime,
@@ -181,9 +181,7 @@ export default function SessionDetail(): React.ReactNode {
             setIsEditing(false);
             refetch();
         } catch (err) {
-            setFormError(
-                err instanceof Error ? err.message : 'An error occurred'
-            );
+            setFormError(getUserErrorMessage(err));
         }
     };
 
@@ -213,9 +211,7 @@ export default function SessionDetail(): React.ReactNode {
                 backTo('/');
             }
         } catch (err) {
-            setFormError(
-                err instanceof Error ? err.message : 'An error occurred'
-            );
+            setFormError(getUserErrorMessage(err));
         }
     };
 
@@ -394,6 +390,7 @@ export default function SessionDetail(): React.ReactNode {
                         title="Edit Session"
                         saving={updateLoading}
                         showRiderPicker={isTrainer}
+                        error={formError}
                         extraActions={
                             <AlertDialog>
                                 <AlertDialogTrigger asChild>


### PR DESCRIPTION
## Summary

- Guard all unguarded async handlers (BarnSection, EditSession, SessionDetail) with try/catch and user-visible `formError` state
- Add `getUserErrorMessage` helper that maps raw "Failed to fetch" to a friendly network error message
- Add `error` prop to `BarnNameEditSheet` and `SessionEditor` so mutation errors display inside the active sheet/overlay
- Browser APIs (clipboard, share) silently degrade; share `AbortError` (user cancelled) is ignored
- Document `formError` pattern in CLAUDE.md and add `/pre-review` to `/gh-issue` finalize workflow

## Test plan

- [ ] Disconnect network → rename barn → error visible inside edit sheet, sheet stays open
- [ ] Disconnect network → regenerate invite code → error visible below regenerate button
- [ ] Copy invite code without clipboard permission → no crash, silent degrade
- [ ] Cancel share sheet → no error; share failure → falls back to copy
- [ ] Disconnect network → create session → friendly network error visible, stays on form
- [ ] Disconnect network → edit session → error visible in edit overlay (not hidden behind it)
- [ ] Browser console shows zero unhandled promise rejections

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)