### PR TITLE
chore(web): add environment banner to dashboard

### DIFF
--- a/packages/api/src/rest/envBanner.ts
+++ b/packages/api/src/rest/envBanner.ts
@@ -1,0 +1,25 @@
+import type { FastifyInstance } from 'fastify';
+import { isDevelopment } from '@/config';
+
+function parseDbName(): string {
+    try {
+        const url = new URL(process.env.DATABASE_URL ?? '');
+        return url.pathname.slice(1);
+    } catch {
+        return 'unknown';
+    }
+}
+
+export async function registerEnvBannerRoutes(
+    app: FastifyInstance
+): Promise<void> {
+    app.get('/api/env-banner', async (_request, reply) => {
+        if (!isDevelopment()) {
+            return reply.status(404).send();
+        }
+
+        const dbLabel = process.env.DATABASE_LABEL || parseDbName();
+        const bgColor = process.env.DATABASE_LABEL_COLOR || '#facc15';
+        return { dbLabel, bgColor };
+    });
+}

--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -18,6 +18,7 @@ import { buildContext } from '@/middleware/auth';
 import { registerVoiceRoutes } from '@/rest/voice';
 import { registerSummaryRoutes } from '@/rest/horseSummary';
 import { registerHealthRoutes } from '@/rest/health';
+import { registerEnvBannerRoutes } from '@/rest/envBanner';
 import * as Sentry from '@sentry/node';
 import { prisma } from '@/db';
 import { sentryApolloPlugin } from '@/lib/sentryApolloPlugin';
@@ -68,6 +69,7 @@ export async function createApiApp(httpsOptions?: {
 
     // REST routes
     await registerHealthRoutes(app);
+    await registerEnvBannerRoutes(app);
     await registerVoiceRoutes(app);
     await registerSummaryRoutes(app);
 

--- a/packages/web/src/components/EnvBanner.tsx
+++ b/packages/web/src/components/EnvBanner.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { apiEndpoint } from '@/lib/api';
+
+export function EnvBanner(): React.ReactNode {
+    const [banner, setBanner] = useState<{
+        dbLabel: string;
+        bgColor: string;
+    } | null>(null);
+
+    useEffect(() => {
+        fetch(apiEndpoint('/api/env-banner'))
+            .then((res) => {
+                if (!res.ok) return null;
+                return res.json() as Promise<{
+                    dbLabel: string;
+                    bgColor: string;
+                }>;
+            })
+            .then((data) => {
+                if (data?.dbLabel) setBanner(data);
+            })
+            .catch(() => {
+                // Silently ignore — production returns 404
+            });
+    }, []);
+
+    if (!banner) return null;
+
+    return (
+        <div
+            className="text-center text-xs font-semibold py-1"
+            style={{ backgroundColor: banner.bgColor, color: '#1a1a1a' }}
+        >
+            DB: {banner.dbLabel}
+        </div>
+    );
+}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client';
 import ActivityCard from '@/components/ActivityCard';
 import { HorseCard } from '@/components/HorseCard';
 import { useAppNavigate } from '@/hooks/useAppNavigate';
+import { EnvBanner } from '@/components/EnvBanner';
 import type {
     GetDashboardDataQuery,
     GetDashboardDataQueryVariables,
@@ -55,8 +56,9 @@ export default function Dashboard(): React.ReactNode {
         );
 
     return (
-        <div className="p-4">
-            <div className="space-y-6">
+        <div>
+            <EnvBanner />
+            <div className="p-4 space-y-6">
                 {/* Herd Activity Section */}
                 <section>
                     <h2 className="text-sm font-medium text-muted-foreground mb-3 px-1">


### PR DESCRIPTION
## Summary
- Adds `/api/env-banner` REST endpoint that returns DB label and background color in non-production environments (404 in production)
- Adds `EnvBanner` component rendered at top of Dashboard showing which database the app is connected to
- Configurable via `DATABASE_LABEL` and `DATABASE_LABEL_COLOR` env vars; falls back to parsing DB name from `DATABASE_URL`

## Test plan
- [ ] Set `DATABASE_LABEL=Local Dev` and `DATABASE_LABEL_COLOR=#facc15` in env, verify yellow banner appears on Dashboard
- [ ] Remove `DATABASE_LABEL` — banner falls back to DB name from `DATABASE_URL`
- [ ] Set `NODE_ENV=production` — endpoint returns 404, no banner rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)