### PR TITLE
docs: add project board workflow and active milestone convention

### DIFF
--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -35,8 +35,24 @@ Check that the current environment matches the issue:
 3. **Check branch name looks right** for this issue (e.g., branch contains a slug derived from the issue title). If it doesn't match, ask the user if they're in the right worktree before proceeding.
 
 4. **Track the issue number** for statusline:
+
     ```bash
     printf "ISSUE=<issue_number>\n" > .state
+    ```
+
+5. **Set project board status to In Progress:**
+    ```bash
+    # Substitute the issue number as an integer, not a string
+    ITEM_ID=$(gh project item-list 1 --owner taco --limit 100 --format json | python3 -c "
+    import json, sys
+    for item in json.load(sys.stdin)['items']:
+        if item['content'].get('number') == <issue_number>:
+            print(item['id']); break
+    ")
+    if [ -z "$ITEM_ID" ]; then echo "ERROR: issue not found in project"; fi
+    # Status field: PVTSSF_lAHOACMj-84BRjUGzg_WM4I, "In Progress": 47fc9ee4
+    gh project item-edit --project-id PVT_kwHOACMj-84BRjUG --id $ITEM_ID \
+      --field-id PVTSSF_lAHOACMj-84BRjUGzg_WM4I --single-select-option-id 47fc9ee4
     ```
 
 Display a summary: title, description, labels, and any relevant comments.

--- a/.claude/skills/write-issue/SKILL.md
+++ b/.claude/skills/write-issue/SKILL.md
@@ -147,6 +147,75 @@ gh issue edit <number> --add-sub-issue <dep-number>
 
 Ask the user about dependencies when context suggests them (e.g., schema work that unblocks a UI issue, or a feature that requires an API endpoint first).
 
+## Project Board
+
+After creating the issue, add it to the **Herdbook Backlog** project board (project #1, owner: taco) and set its custom fields.
+
+### Add to project and set fields
+
+```bash
+# Add issue to project
+gh project item-add 1 --owner taco --url "https://github.com/taco/herdbook/issues/<number>"
+
+# Get the item ID (substitute the issue number as an integer, not a string)
+ITEM_ID=$(gh project item-list 1 --owner taco --limit 100 --format json | python3 -c "
+import json, sys
+for item in json.load(sys.stdin)['items']:
+    if item['content'].get('number') == <issue_number>:
+        print(item['id']); break
+")
+if [ -z "$ITEM_ID" ]; then echo "ERROR: issue not found in project"; exit 1; fi
+
+# Set all three fields (Priority, Type, Package)
+PROJECT_ID="PVT_kwHOACMj-84BRjUG"
+gh project item-edit --project-id $PROJECT_ID --id $ITEM_ID --field-id <PRIORITY_FIELD_ID> --single-select-option-id <PRIORITY_OPTION_ID>
+gh project item-edit --project-id $PROJECT_ID --id $ITEM_ID --field-id <TYPE_FIELD_ID> --single-select-option-id <TYPE_OPTION_ID>
+gh project item-edit --project-id $PROJECT_ID --id $ITEM_ID --field-id <PACKAGE_FIELD_ID> --single-select-option-id <PACKAGE_OPTION_ID>
+```
+
+### Field IDs
+
+**Priority** (`PVTSSF_lAHOACMj-84BRjUGzg_WM8I`) — source of truth for prioritization (no priority labels):
+| Option | ID |
+|--------|-----|
+| P0-critical | `2c26d657` |
+| P1-high | `95acdd5f` |
+| P2-medium | `7771b4e8` |
+| P3-low | `aa387660` |
+
+**Type** (`PVTSSF_lAHOACMj-84BRjUGzg_WPJY`):
+| Option | ID |
+|--------|-----|
+| feature | `7711276b` |
+| bug | `8720351c` |
+| chore | `1bb60516` |
+| refactor | `67d23443` |
+| docs | `55b2d675` |
+
+**Package** (`PVTSSF_lAHOACMj-84BRjUGzg_WM8c`):
+| Option | ID |
+|--------|-----|
+| api | `0ecce83b` |
+| web | `ae70ba8a` |
+| e2e | `1f4d129d` |
+| both | `211c2787` |
+| infra | `75373afa` |
+
+### Choosing Priority
+
+- Ask the user what priority to assign.
+- Bugs always default to P1-high regardless of milestone (security bugs to P0-critical).
+- If the issue belongs to the **active milestone**, default to P2-medium unless the user says otherwise.
+- Issues in non-active milestones default to P3-low.
+
+### Choosing Milestone
+
+Ask the user if the issue belongs to an existing milestone. The active milestone is marked with `[ACTIVE]` in its description:
+
+```bash
+gh api repos/taco/herdbook/milestones --jq '.[] | select(.description | startswith("[ACTIVE]")) | "\(.number): \(.title)"'
+```
+
 ## Quick Quality Checklist
 
 - Title is specific and searchable.
@@ -156,3 +225,4 @@ Ask the user about dependencies when context suggests them (e.g., schema work th
 - Links exist for deep context.
 - Labels applied: exactly one type label + applicable scope labels.
 - Dependencies linked if applicable.
+- Added to project board with Priority, Type, and Package set.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,18 @@ Leave the codebase slightly better than you found it. When a change reveals near
 - The top message should be short and easy to read without losing context
 - Seperate details should be order in terms for weight, most important at the top
 
+## Project Board
+
+All issues are tracked in the [Herdbook Backlog](https://github.com/users/taco/projects/1) GitHub Project (project #1, owner: taco).
+
+- **Priority lives on the board** (custom field), not in labels. Do not create priority labels.
+- Every new issue must be added to the project with **Priority**, **Type**, and **Package** fields set (see `/write-issue` skill for field IDs).
+- When starting work on an issue, set its Status to **In Progress** (see `/gh-issue` skill).
+- **Active milestone**: Marked with `[ACTIVE]` prefix in its GitHub description. Issues in the active milestone default to P2-medium; other milestones default to P3-low. Bugs always default to P1-high regardless of milestone.
+    - Query: `gh api repos/taco/herdbook/milestones --jq '.[] | select(.description | startswith("[ACTIVE]"))'`
+    - To change: remove `[ACTIVE]` from old milestone description, add to new one.
+- Cherry-picking across milestones is fine — priority on the board is the final word on what to work next.
+
 ## Design Docs
 
 - After `/design` creates issues on GitHub, update the design doc's issue headings to use real issue numbers with full links: `### [#84](https://github.com/taco/herdbook/issues/84): Title`


### PR DESCRIPTION
## Summary
- Add Project Board section to CLAUDE.md documenting priority source of truth, active milestone convention, and field rules
- Update `/write-issue` skill to add new issues to the Herdbook Backlog project with Priority, Type, and Package fields
- Update `/gh-issue` skill to set board Status to In Progress when starting work
- Active milestone tracked via `[ACTIVE]` prefix in GitHub milestone description

## Context
Set up GitHub Projects (v2) as a scannable backlog with table/board/roadmap views. Priority lives on the board as a custom field — no priority labels. Skills now integrate with the board so it stays current as issues are created and worked on.