### PR TITLE
feat(web): default to voice capture for all session entry points

### DIFF
--- a/packages/e2e/tests/regression/horse-profile.spec.ts
+++ b/packages/e2e/tests/regression/horse-profile.spec.ts
@@ -21,11 +21,9 @@ test.describe('Horse Profile', () => {
         await page.click(`text=${TEST_HORSE_NAME}`);
 
         await page.getByRole('button', { name: 'Log Session' }).click();
-        await expect(page).toHaveURL('/sessions/new');
+        await expect(page).toHaveURL('/sessions/voice');
 
-        // Horse should be prefilled in the summary row
-        await expect(
-            page.getByRole('button', { name: 'Edit Horse' })
-        ).toContainText(TEST_HORSE_NAME);
+        // Horse name should appear in the voice capture header
+        await expect(page.getByText(TEST_HORSE_NAME)).toBeVisible();
     });
 });

--- a/packages/web/src/pages/HorseProfile.tsx
+++ b/packages/web/src/pages/HorseProfile.tsx
@@ -261,8 +261,11 @@ export default function HorseProfile(): React.ReactNode {
                     size="lg"
                     className="pointer-events-auto shadow-lg rounded-full px-6 h-12"
                     onClick={() =>
-                        push('/sessions/new', {
-                            state: { prefill: { horseId: id } },
+                        push('/sessions/voice', {
+                            state: {
+                                horseId: id,
+                                horseName: horse.name,
+                            },
                         })
                     }
                 >

--- a/packages/web/src/pages/Sessions.tsx
+++ b/packages/web/src/pages/Sessions.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
-import { Calendar, SlidersHorizontal } from 'lucide-react';
+import { Calendar, Mic, SlidersHorizontal } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -179,7 +179,7 @@ export default function Sessions(): React.ReactNode {
     };
 
     return (
-        <div className="p-4 space-y-4">
+        <div className="p-4 pb-24 space-y-4">
             <h1 className="text-lg font-semibold">Sessions</h1>
 
             {/* Filter chip bar */}
@@ -251,6 +251,18 @@ export default function Sessions(): React.ReactNode {
                     )}
                 </div>
             )}
+
+            {/* Voice capture FAB */}
+            <div className="fixed bottom-24 right-4 z-20">
+                <Button
+                    size="icon"
+                    className="h-14 w-14 rounded-full shadow-lg"
+                    onClick={() => push('/sessions/voice')}
+                    aria-label="Log session"
+                >
+                    <Mic className="h-6 w-6" />
+                </Button>
+            </div>
 
             {/* Horse filter */}
             <PickerSheet

--- a/packages/web/src/pages/VoiceSessionCapture.tsx
+++ b/packages/web/src/pages/VoiceSessionCapture.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
 import {
@@ -38,6 +39,13 @@ const GET_RIDERS_QUERY = gql`
 
 export default function VoiceSessionCapture() {
     const { push, back } = useAppNavigate();
+    const location = useLocation();
+    const locationState = location.state as {
+        horseId?: string;
+        horseName?: string;
+    } | null;
+    const prefillHorseId = locationState?.horseId ?? null;
+    const prefillHorseName = locationState?.horseName ?? null;
 
     const { data: horsesData, loading: horsesLoading } =
         useQuery<GetHorsesQuery>(GET_HORSES_QUERY);
@@ -72,7 +80,7 @@ export default function VoiceSessionCapture() {
             push('/sessions/new', {
                 state: {
                     prefill: {
-                        horseId: parsedFields.horseId,
+                        horseId: parsedFields.horseId ?? prefillHorseId,
                         riderId: parsedFields.riderId,
                         date: formatAsDateTimeLocalValue(new Date()),
                         durationMinutes: parsedFields.durationMinutes,
@@ -85,7 +93,7 @@ export default function VoiceSessionCapture() {
                 },
             });
         }
-    }, [state, parsedFields, push]);
+    }, [state, parsedFields, push, prefillHorseId]);
 
     const handleBack = () => {
         if (state === 'recording') {
@@ -95,7 +103,11 @@ export default function VoiceSessionCapture() {
     };
 
     const handleManualEntry = () => {
-        push('/sessions/new');
+        push('/sessions/new', {
+            state: prefillHorseId
+                ? { prefill: { horseId: prefillHorseId } }
+                : undefined,
+        });
     };
 
     const isRecording = state === 'recording';
@@ -116,7 +128,14 @@ export default function VoiceSessionCapture() {
                 >
                     <ChevronLeft className="h-6 w-6" />
                 </Button>
-                <h1 className="text-lg font-semibold">Log Session</h1>
+                <div className="flex-1 min-w-0">
+                    <h1 className="text-lg font-semibold">Log Session</h1>
+                    {prefillHorseName && (
+                        <p className="text-sm text-muted-foreground truncate">
+                            {prefillHorseName}
+                        </p>
+                    )}
+                </div>
             </div>
 
             {/* Main content */}
@@ -192,12 +211,21 @@ export default function VoiceSessionCapture() {
 
             {/* Footer hint */}
             {(isIdle || isRecording) && !dataLoading && (
-                <div className="p-6 pt-0">
+                <div className="p-6 pt-0 space-y-3">
                     <p className="text-center text-base text-muted-foreground">
                         {isRecording
                             ? 'Describe your session: horse, duration, what you worked on...'
                             : "Speak naturally about your ride and we'll extract the details"}
                     </p>
+                    {isIdle && (
+                        <Button
+                            variant="link"
+                            onClick={handleManualEntry}
+                            className="mx-auto text-sm"
+                        >
+                            Enter manually
+                        </Button>
+                    )}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Summary
- **HorseProfile**: FAB now navigates to `/sessions/voice` with horse context instead of `/sessions/new`
- **Sessions**: Added Mic FAB for voice-first session creation from the sessions list
- **VoiceSessionCapture**: Accepts horse context via location state, shows horse name in header, forwards horse prefill on parse success and manual entry, adds "Enter manually" escape hatch in idle state
- **E2E**: Updated horse-profile regression test for new voice-first navigation

Fixes #134

## Test plan
- [x] Horse profile -> Log Session -> voice capture shows horse name subtitle
- [x] Voice capture (from horse) -> Enter manually -> EditSession with horse prefilled
- [x] Voice capture (from horse) -> record + parse -> EditSession with horse prefilled (or parsed horse wins)
- [x] Sessions page -> Mic FAB -> voice capture without horse name
- [x] Center Log tab -> voice capture (no regression)
- [x] "Enter manually" visible in idle state, hidden during recording