### PR TITLE
chore(ci): track web bundle size on PRs

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,36 @@
+name: Bundle Size
+
+on:
+    pull_request:
+        branches: [main]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    bundle-size:
+        runs-on: ubuntu-latest
+        continue-on-error: true
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '24'
+                  cache: 'pnpm'
+
+            - name: Compare compressed size
+              uses: preactjs/compressed-size-action@v2
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+                  pattern: 'packages/web/dist/assets/**/*.{js,css}'
+                  exclude: '**/*.map'
+                  strip-hash: '\-([a-zA-Z0-9_-]{8})\.'
+                  build-script: 'build:web'


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/bundle-size.yml` — a new CI job that posts a sticky comment on every PR with per-file gzipped size deltas for `packages/web/dist/assets/**/*.{js,css}` vs `main`, using [`preactjs/compressed-size-action@v2`](https://github.com/preactjs/compressed-size-action).
- Advisory only: `continue-on-error: true` + the action's default non-failing behavior means size increases never block merge.
- Uses the root `build:web` script so only the web package builds (no API / Prisma / database needed).
- `strip-hash` regex matches Vite's 8-char content hash so renames on unchanged files don't appear as add/remove.
- Grants `pull-requests: write` because the repo's `default_workflow_permissions` is `read`, which would otherwise block the sticky-comment post.

Closes #138.

## Test plan

- [ ] `Bundle Size` check appears on this PR alongside `checks`, `api-test`, and `e2e-smoke`
- [ ] Sticky comment from `github-actions[bot]` appears with a per-file size table (expected: no changes, since this PR only touches `.github/workflows/`)
- [ ] The `Bundle Size` job finishes non-failing (✅ or neutral)
- [ ] Future PR touching `packages/web` shows non-zero deltas
- [ ] Re-running on a new commit updates the same comment instead of spamming a new one
