### PR TITLE
chore(web): remove Sentry tracing integration

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -5,8 +5,6 @@ import {
     Route,
     Navigate,
 } from 'react-router-dom';
-import * as Sentry from '@sentry/react';
-
 import { useAuth } from '@/context/AuthContext';
 import { DevToolbar } from '@/components/DevToolbar';
 import { ServiceWorkerUpdater } from '@/components/ServiceWorkerUpdater';
@@ -25,8 +23,6 @@ import VoiceSessionCapture from '@/pages/VoiceSessionCapture';
 import TabLayout from '@/layouts/TabLayout';
 import FullScreenLayout from '@/layouts/FullScreenLayout';
 
-const SentryRoutes = Sentry.withSentryReactRouterV7Routing(Routes);
-
 const PublicRoute: React.FC<{ element: React.ReactElement }> = ({
     element,
 }) => {
@@ -43,7 +39,7 @@ const TrainerRoute: React.FC<{ element: React.ReactElement }> = ({
 
 function AppRoutes(): React.ReactNode {
     return (
-        <SentryRoutes>
+        <Routes>
             <Route
                 path="/login"
                 element={<PublicRoute element={<Login />} />}
@@ -79,7 +75,7 @@ function AppRoutes(): React.ReactNode {
             </Route>
 
             <Route path="*" element={<Navigate to="/" />} />
-        </SentryRoutes>
+        </Routes>
     );
 }
 

--- a/packages/web/src/lib/apollo.ts
+++ b/packages/web/src/lib/apollo.ts
@@ -3,21 +3,18 @@ import { SetContextLink } from '@apollo/client/link/context';
 import { ErrorLink } from '@apollo/client/link/error';
 import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { GRAPHQL_URL } from './api';
-import { captureGraphQLError, GRAPHQL_OP_HEADER } from './sentry';
+import { captureGraphQLError } from './sentry';
 
 const httpLink = new HttpLink({
     uri: GRAPHQL_URL,
 });
 
-const authLink = new SetContextLink(({ headers }, request) => {
+const authLink = new SetContextLink(({ headers }) => {
     const token = localStorage.getItem('token');
     return {
         headers: {
             ...headers,
             authorization: token ? `Bearer ${token}` : '',
-            ...(request.operationName && {
-                [GRAPHQL_OP_HEADER]: request.operationName,
-            }),
         },
     };
 });

--- a/packages/web/src/lib/sentry.ts
+++ b/packages/web/src/lib/sentry.ts
@@ -1,11 +1,4 @@
 import * as Sentry from '@sentry/react';
-import { useEffect } from 'react';
-import {
-    useLocation,
-    useNavigationType,
-    createRoutesFromChildren,
-    matchRoutes,
-} from 'react-router-dom';
 
 const SENSITIVE_KEY_PATTERN =
     /token|authorization|password|secret|credential|session/i;
@@ -56,49 +49,15 @@ export function beforeSend(event: Sentry.ErrorEvent): Sentry.ErrorEvent {
     return event;
 }
 
-/** Header name used to pass the GraphQL operation name to Sentry span enrichment. */
-export const GRAPHQL_OP_HEADER = 'x-graphql-operation-name';
-
-function buildTracePropagationTargets(): (string | RegExp)[] {
-    const targets: (string | RegExp)[] = [/^\/graphql/, /^\/api\//];
-    const apiUrl = import.meta.env.VITE_API_URL;
-    if (apiUrl) {
-        targets.push(apiUrl);
-    }
-    return targets;
-}
-
 export function initSentry(): void {
     const dsn = import.meta.env.VITE_SENTRY_DSN;
     if (!dsn) return;
-
-    const tracesSampleRate = parseFloat(
-        import.meta.env.VITE_SENTRY_TRACES_SAMPLE_RATE ?? '0'
-    );
 
     Sentry.init({
         dsn,
         sendDefaultPii: false,
         environment: import.meta.env.MODE,
         beforeSend,
-        integrations: [
-            Sentry.reactRouterV7BrowserTracingIntegration({
-                useEffect,
-                useLocation,
-                useNavigationType,
-                createRoutesFromChildren,
-                matchRoutes,
-                onRequestSpanStart(span, { headers }) {
-                    const opName = headers?.get?.(GRAPHQL_OP_HEADER);
-                    if (opName) {
-                        span.updateName(`POST /graphql (${opName})`);
-                        span.setAttribute('graphql.operation', opName);
-                    }
-                },
-            }),
-        ],
-        tracesSampleRate: isNaN(tracesSampleRate) ? 0 : tracesSampleRate,
-        tracePropagationTargets: buildTracePropagationTargets(),
     });
 }
 

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -8,8 +8,6 @@ interface ImportMetaEnv {
     readonly VITE_DEV_AUTOLOGIN?: string;
     /** Sentry DSN for error tracking. Omit to disable Sentry. */
     readonly VITE_SENTRY_DSN?: string;
-    /** Sentry performance traces sample rate (0–1). Defaults to 0 (disabled). */
-    readonly VITE_SENTRY_TRACES_SAMPLE_RATE?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

- Removes Sentry's browser-tracing integration while keeping error reporting fully intact. Actual bundle impact per CI: **−216 B (−0.11%)** — tree-shaking was already eliminating most of the dead tracing code, so removing the usage only nets the ~200 bytes of local wiring (the `withSentryReactRouterV7Routing` wrapper, `tracesSampleRate`/`tracePropagationTargets` config, `onRequestSpanStart` hook, `GRAPHQL_OP_HEADER` plumbing). The bulk of Sentry's footprint (~25–30 kB gzipped, or roughly 14.5% of rendered bundle across `@sentry/core` + `@sentry/browser`) ships regardless of which integrations you enable — it's the SDK core, not the features.
- Removes `reactRouterV7BrowserTracingIntegration`, `tracesSampleRate`, `tracePropagationTargets`, the `withSentryReactRouterV7Routing(Routes)` wrapper in `App.tsx`, the `GRAPHQL_OP_HEADER` operation-name enrichment plumbing through `apollo.ts`, and the `VITE_SENTRY_TRACES_SAMPLE_RATE` env var type.
- Error reporting is unchanged: `Sentry.init` with DSN + `beforeSend` PII redaction, `Sentry.ErrorBoundary` in `main.tsx`, `setSentryUser`, and `captureGraphQLError` from apollo's error link all remain.

## Why

Cleanup + prerequisite for the planned Sentry lazy-load work. The real bundle/CWV win from Sentry lives in moving the whole SDK off the critical path via `requestIdleCallback`, not in toggling individual integrations — that's the follow-up this PR unblocks. Lazy-loading is blocked on perf logging landing first so the impact can be measured, not guessed.

CI bundle-size report:

| Metric | Value |
|---|---:|
| Total web bundle (post-merge) | 188 kB |
| `index-*.js` delta | −216 B (−0.12%) |
| Overall delta | −216 B (−0.11%) |

## Test plan

- [x] `pnpm run check` (format + typecheck) clean
- [x] `pnpm --filter web test` — 18/18 passing (`sentry.test.ts` unchanged, still covers `beforeSend` PII redaction)
- [x] `pnpm --filter web build` succeeds; CI bundle-size job posted the delta (−216 B / −0.11%)
- [x] Load the app in dev, confirm no Sentry-init console warnings and that routing still works
- [x] Throw a test error, confirm it still reaches Sentry (in an env with a DSN)
